### PR TITLE
fix: support real firestore relay startup

### DIFF
--- a/firebase/.firebaserc
+++ b/firebase/.firebaserc
@@ -1,0 +1,7 @@
+{
+  "projects": {
+    "default": "remotecodex-c52ae"
+  },
+  "targets": {},
+  "etags": {}
+}

--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -1,5 +1,24 @@
 {
-  "indexes": [],
+  "indexes": [
+    {
+      "collectionGroup": "commands",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
+          "fieldPath": "targetPcBridgeId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
   "fieldOverrides": []
 }
 

--- a/pc-bridge/config.example.json
+++ b/pc-bridge/config.example.json
@@ -3,6 +3,7 @@
   "displayName": "Home PC",
   "workspaceName": "codex-remote-android",
   "workspacePath": "D:\\Claude\\FlutterApp\\codex-remote-android",
+  "ownerUserId": "",
   "firebaseProjectId": "your-firebase-project-id",
   "serviceAccountPath": "D:\\secure\\codex-remote-service-account.json",
   "relayMode": "local",

--- a/pc-bridge/src/lib/config.ts
+++ b/pc-bridge/src/lib/config.ts
@@ -34,6 +34,7 @@ export function normalizeConfig(raw: RawConfig): BridgeConfig {
     displayName: required(raw.displayName, "displayName"),
     workspaceName: required(raw.workspaceName, "workspaceName"),
     workspacePath: required(raw.workspacePath, "workspacePath"),
+    ownerUserId: raw.ownerUserId,
     firebaseProjectId: raw.firebaseProjectId,
     serviceAccountPath: raw.serviceAccountPath,
     relayMode,

--- a/pc-bridge/src/lib/firestoreRelayRepository.ts
+++ b/pc-bridge/src/lib/firestoreRelayRepository.ts
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { cert, getApps, initializeApp } from "firebase-admin/app";
 import {
-  FieldPath,
   FieldValue,
   Timestamp,
   getFirestore,
@@ -125,23 +124,19 @@ export class FirestoreRelayRepository implements CommandRepository {
   }
 
   async updateHeartbeat(pcBridgeId: string, now: Date): Promise<void> {
-    const firestore = await this.getFirestore();
-    const snapshot = await firestore
-      .collectionGroup("pcBridges")
-      .where(FieldPath.documentId(), "==", pcBridgeId)
-      .limit(1)
-      .get();
-
-    const bridge = snapshot.docs[0];
-    if (!bridge) {
+    if (!this.config.ownerUserId) {
       return;
     }
 
-    await bridge.ref.update({
+    const firestore = await this.getFirestore();
+    await firestore.doc(`users/${this.config.ownerUserId}/pcBridges/${pcBridgeId}`).set({
+      pcBridgeId,
+      displayName: this.config.displayName,
+      workspaceName: this.config.workspaceName,
       lastSeenAt: Timestamp.fromDate(now),
       status: "active",
       version: "0.1.0",
-    });
+    }, { merge: true });
   }
 
   private async getFirestore(): Promise<Firestore> {

--- a/pc-bridge/src/lib/types.ts
+++ b/pc-bridge/src/lib/types.ts
@@ -9,6 +9,7 @@ export type BridgeConfig = {
   displayName: string;
   workspaceName: string;
   workspacePath: string;
+  ownerUserId?: string;
   firebaseProjectId?: string;
   serviceAccountPath?: string;
   relayMode: RelayMode;


### PR DESCRIPTION
## Summary
- Fix Firestore heartbeat startup by avoiding collection group documentId lookup for pcBridges.
- Add optional ownerUserId config for direct heartbeat writes once the app user uid is known.
- Add the commands collection group composite index and commit the Firebase default project mapping.

Closes #30

## Verification
- npm.cmd run check
- firebase deploy --only firestore:indexes
- firebase firestore:indexes shows commands index READY
- npm.cmd run start reaches `No queued command found.` with relayMode firestore