### PR TITLE
feat: add anonymous auth startup baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Setup Status
 
-- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Firebase Core/Auth/Firestore dependencies are being wired into the startup flow.
+- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup now initializes Firebase, performs anonymous sign-in, and stores the MVP default PC bridge ID.
 - `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can reach Firebase in `stub` mode.
 - `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules and command query index.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.
 
 ## Current Phase
 
-Phase 5 Android app MVP is in progress. The first task is the Flutter Android scaffold; subsequent tasks add Firebase initialization, anonymous auth, sessions, command submission, and Xperia 1 III validation.
+Phase 5 Android app MVP is in progress. Flutter scaffold, Firebase initialization, and anonymous-auth baseline are in place; session list, command submission, and Xperia 1 III validation remain.
 
 ## Documents
 

--- a/app/README.md
+++ b/app/README.md
@@ -22,7 +22,15 @@ Firebase SDK設定で、ユーザーが取得した `google-services.json` を `
 - `firebase_auth`
 - `cloud_firestore`
 
-起動時に `Firebase.initializeApp()` を実行し、初期化結果を表示する。匿名認証、セッション一覧、コマンド送信は後続Issueで実装する。
+起動時に次を実行する。
+
+1. `Firebase.initializeApp()`
+2. Firebase Anonymous Authの `signInAnonymously()`
+3. `/users/{uid}` へMVP接続先 `home-main-pc` を保存
+
+初回実機起動後、画面に表示される `User uid` をPCブリッジの `config.local.json` の `ownerUserId` に設定すると、PCブリッジのheartbeatを `/users/{uid}/pcBridges/home-main-pc` に保存できる。
+
+セッション一覧、コマンド送信は後続Issueで実装する。
 
 ## MVP責務
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,15 +1,46 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
+const defaultPcBridgeId = 'home-main-pc';
+
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(RemoteCodexApp(firebaseInitialization: Firebase.initializeApp()));
+  runApp(RemoteCodexApp(bootstrap: bootstrapRemoteCodex()));
+}
+
+Future<AppBootstrap> bootstrapRemoteCodex() async {
+  await Firebase.initializeApp();
+
+  final credential = await FirebaseAuth.instance.signInAnonymously();
+  final uid = credential.user?.uid;
+
+  if (uid == null || uid.isEmpty) {
+    throw StateError('Anonymous sign-in did not return a user uid.');
+  }
+
+  await FirebaseFirestore.instance.collection('users').doc(uid).set({
+    'uid': uid,
+    'defaultPcBridgeId': defaultPcBridgeId,
+    'updatedAt': FieldValue.serverTimestamp(),
+    'lastSignedInAt': FieldValue.serverTimestamp(),
+  }, SetOptions(merge: true));
+
+  return AppBootstrap(uid: uid, pcBridgeId: defaultPcBridgeId);
+}
+
+class AppBootstrap {
+  const AppBootstrap({required this.uid, required this.pcBridgeId});
+
+  final String uid;
+  final String pcBridgeId;
 }
 
 class RemoteCodexApp extends StatelessWidget {
-  const RemoteCodexApp({super.key, required this.firebaseInitialization});
+  const RemoteCodexApp({super.key, required this.bootstrap});
 
-  final Future<FirebaseApp> firebaseInitialization;
+  final Future<AppBootstrap> bootstrap;
 
   @override
   Widget build(BuildContext context) {
@@ -19,41 +50,37 @@ class RemoteCodexApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2563EB)),
         useMaterial3: true,
       ),
-      home: FirebaseStartupView(firebaseInitialization: firebaseInitialization),
+      home: StartupView(bootstrap: bootstrap),
     );
   }
 }
 
-class FirebaseStartupView extends StatelessWidget {
-  const FirebaseStartupView({super.key, required this.firebaseInitialization});
+class StartupView extends StatelessWidget {
+  const StartupView({super.key, required this.bootstrap});
 
-  final Future<FirebaseApp> firebaseInitialization;
+  final Future<AppBootstrap> bootstrap;
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<FirebaseApp>(
-      future: firebaseInitialization,
+    return FutureBuilder<AppBootstrap>(
+      future: bootstrap,
       builder: (context, snapshot) {
         final Widget body;
 
         if (snapshot.connectionState != ConnectionState.done) {
           body = const _StartupMessage(
-            title: 'Initializing Firebase',
+            title: 'Signing in',
             message: 'Preparing secure relay access.',
             child: CircularProgressIndicator(),
           );
         } else if (snapshot.hasError) {
           body = _StartupMessage(
-            title: 'Firebase setup failed',
+            title: 'Startup failed',
             message: snapshot.error.toString(),
             child: const Icon(Icons.error_outline, size: 36),
           );
         } else {
-          body = const _StartupMessage(
-            title: 'RemoteCodex',
-            message: 'Firebase is ready. Session features are next.',
-            child: Icon(Icons.check_circle_outline, size: 36),
-          );
+          body = _ReadyView(bootstrap: snapshot.requireData);
         }
 
         return Scaffold(
@@ -61,6 +88,72 @@ class FirebaseStartupView extends StatelessWidget {
           body: SafeArea(child: body),
         );
       },
+    );
+  }
+}
+
+class _ReadyView extends StatelessWidget {
+  const _ReadyView({required this.bootstrap});
+
+  final AppBootstrap bootstrap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Icon(Icons.check_circle_outline, size: 40),
+            const SizedBox(height: 20),
+            Text(
+              'RemoteCodex',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Anonymous sign-in is ready.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            _InfoRow(label: 'PC bridge', value: bootstrap.pcBridgeId),
+            const SizedBox(height: 12),
+            _InfoRow(label: 'User uid', value: bootstrap.uid),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label, style: Theme.of(context).textTheme.labelMedium),
+            const SizedBox(height: 4),
+            SelectableText(value),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,38 +1,20 @@
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remote_codex/main.dart';
 
 void main() {
-  testWidgets('shows startup ready state after Firebase initialization', (tester) async {
-    await tester.pumpWidget(RemoteCodexApp(firebaseInitialization: Future<FirebaseApp>.value(FakeFirebaseApp())));
+  testWidgets('shows anonymous auth ready state', (tester) async {
+    await tester.pumpWidget(
+      RemoteCodexApp(
+        bootstrap: Future<AppBootstrap>.value(
+          const AppBootstrap(uid: 'test-uid', pcBridgeId: defaultPcBridgeId),
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('RemoteCodex'), findsWidgets);
-    expect(find.text('Firebase is ready. Session features are next.'), findsOneWidget);
+    expect(find.text('Anonymous sign-in is ready.'), findsOneWidget);
+    expect(find.text('home-main-pc'), findsOneWidget);
+    expect(find.text('test-uid'), findsOneWidget);
   });
-}
-
-class FakeFirebaseApp implements FirebaseApp {
-  @override
-  String get name => '[DEFAULT]';
-
-  @override
-  FirebaseOptions get options => const FirebaseOptions(
-        apiKey: 'test-api-key',
-        appId: 'test-app-id',
-        messagingSenderId: 'test-sender-id',
-        projectId: 'test-project-id',
-      );
-
-  @override
-  bool get isAutomaticDataCollectionEnabled => false;
-
-  @override
-  Future<void> delete() async {}
-
-  @override
-  Future<void> setAutomaticDataCollectionEnabled(bool enabled) async {}
-
-  @override
-  Future<void> setAutomaticResourceManagementEnabled(bool enabled) async {}
 }


### PR DESCRIPTION
## Summary
- Add startup bootstrap that initializes Firebase, signs in anonymously, and records `defaultPcBridgeId: home-main-pc` under `/users/{uid}`.
- Show the anonymous user uid and MVP PC bridge target in the app startup screen.
- Update README files with the current Phase 5 state and the `ownerUserId` handoff for PC bridge heartbeat.

Closes #34

## Verification
- flutter analyze
- flutter test
- flutter build apk --debug

## Notes
- Real-device anonymous auth confirmation is left for #37 wireless device validation.