### PR TITLE
feat: add session list and creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Setup Status
 
-- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup now initializes Firebase, performs anonymous sign-in, and stores the MVP default PC bridge ID.
+- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores the MVP default PC bridge ID, and shows the authenticated user's session list.
 - `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can reach Firebase in `stub` mode.
 - `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules and command query index.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.
 
 ## Current Phase
 
-Phase 5 Android app MVP is in progress. Flutter scaffold, Firebase initialization, and anonymous-auth baseline are in place; session list, command submission, and Xperia 1 III validation remain.
+Phase 5 Android app MVP is in progress. Flutter scaffold, Firebase initialization, anonymous-auth baseline, and session list/create are in place; command submission and Xperia 1 III validation remain.
 
 ## Documents
 

--- a/app/README.md
+++ b/app/README.md
@@ -30,7 +30,9 @@ Firebase SDK設定で、ユーザーが取得した `google-services.json` を `
 
 初回実機起動後、画面に表示される `User uid` をPCブリッジの `config.local.json` の `ownerUserId` に設定すると、PCブリッジのheartbeatを `/users/{uid}/pcBridges/home-main-pc` に保存できる。
 
-セッション一覧、コマンド送信は後続Issueで実装する。
+セッション一覧では `/users/{uid}/sessions` を `updatedAt` 降順で購読し、`New session` から新規セッションを作成する。作成時はMVP接続先として `targetPcBridgeId: home-main-pc` を保存する。
+
+コマンド送信は後続Issueで実装する。
 
 ## MVP責務
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -7,10 +9,16 @@ const defaultPcBridgeId = 'home-main-pc';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  runApp(RemoteCodexApp(bootstrap: bootstrapRemoteCodex()));
+  final firestore = FirebaseFirestore.instance;
+  runApp(
+    RemoteCodexApp(
+      bootstrap: bootstrapRemoteCodex(firestore),
+      sessionRepository: FirestoreSessionRepository(firestore),
+    ),
+  );
 }
 
-Future<AppBootstrap> bootstrapRemoteCodex() async {
+Future<AppBootstrap> bootstrapRemoteCodex(FirebaseFirestore firestore) async {
   await Firebase.initializeApp();
 
   final credential = await FirebaseAuth.instance.signInAnonymously();
@@ -20,7 +28,7 @@ Future<AppBootstrap> bootstrapRemoteCodex() async {
     throw StateError('Anonymous sign-in did not return a user uid.');
   }
 
-  await FirebaseFirestore.instance.collection('users').doc(uid).set({
+  await firestore.collection('users').doc(uid).set({
     'uid': uid,
     'defaultPcBridgeId': defaultPcBridgeId,
     'updatedAt': FieldValue.serverTimestamp(),
@@ -37,10 +45,78 @@ class AppBootstrap {
   final String pcBridgeId;
 }
 
+class SessionSummary {
+  const SessionSummary({
+    required this.id,
+    required this.title,
+    required this.status,
+    this.lastResultPreview,
+    this.lastErrorPreview,
+  });
+
+  final String id;
+  final String title;
+  final String status;
+  final String? lastResultPreview;
+  final String? lastErrorPreview;
+}
+
+abstract class SessionRepository {
+  Stream<List<SessionSummary>> watchSessions(String uid);
+  Future<void> createSession({required String uid, required String pcBridgeId});
+}
+
+class FirestoreSessionRepository implements SessionRepository {
+  FirestoreSessionRepository(this.firestore);
+
+  final FirebaseFirestore firestore;
+
+  @override
+  Stream<List<SessionSummary>> watchSessions(String uid) {
+    return firestore
+        .collection('users')
+        .doc(uid)
+        .collection('sessions')
+        .orderBy('updatedAt', descending: true)
+        .snapshots()
+        .map((snapshot) => snapshot.docs.map((doc) {
+              final data = doc.data();
+              return SessionSummary(
+                id: doc.id,
+                title: (data['title'] as String?)?.trim().isNotEmpty == true ? data['title'] as String : 'Untitled session',
+                status: data['status'] as String? ?? 'idle',
+                lastResultPreview: data['lastResultPreview'] as String?,
+                lastErrorPreview: data['lastErrorPreview'] as String?,
+              );
+            }).toList());
+  }
+
+  @override
+  Future<void> createSession({required String uid, required String pcBridgeId}) async {
+    final now = DateTime.now();
+    final title = 'Session ${now.year}-${two(now.month)}-${two(now.day)} ${two(now.hour)}:${two(now.minute)}';
+
+    await firestore.collection('users').doc(uid).collection('sessions').add({
+      'title': title,
+      'status': 'idle',
+      'targetPcBridgeId': pcBridgeId,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+}
+
+String two(int value) => value.toString().padLeft(2, '0');
+
 class RemoteCodexApp extends StatelessWidget {
-  const RemoteCodexApp({super.key, required this.bootstrap});
+  const RemoteCodexApp({
+    super.key,
+    required this.bootstrap,
+    required this.sessionRepository,
+  });
 
   final Future<AppBootstrap> bootstrap;
+  final SessionRepository sessionRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -50,15 +126,23 @@ class RemoteCodexApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2563EB)),
         useMaterial3: true,
       ),
-      home: StartupView(bootstrap: bootstrap),
+      home: StartupView(
+        bootstrap: bootstrap,
+        sessionRepository: sessionRepository,
+      ),
     );
   }
 }
 
 class StartupView extends StatelessWidget {
-  const StartupView({super.key, required this.bootstrap});
+  const StartupView({
+    super.key,
+    required this.bootstrap,
+    required this.sessionRepository,
+  });
 
   final Future<AppBootstrap> bootstrap;
+  final SessionRepository sessionRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -80,7 +164,10 @@ class StartupView extends StatelessWidget {
             child: const Icon(Icons.error_outline, size: 36),
           );
         } else {
-          body = _ReadyView(bootstrap: snapshot.requireData);
+          body = SessionListView(
+            bootstrap: snapshot.requireData,
+            sessionRepository: sessionRepository,
+          );
         }
 
         return Scaffold(
@@ -92,10 +179,163 @@ class StartupView extends StatelessWidget {
   }
 }
 
-class _ReadyView extends StatelessWidget {
-  const _ReadyView({required this.bootstrap});
+class SessionListView extends StatefulWidget {
+  const SessionListView({
+    super.key,
+    required this.bootstrap,
+    required this.sessionRepository,
+  });
 
   final AppBootstrap bootstrap;
+  final SessionRepository sessionRepository;
+
+  @override
+  State<SessionListView> createState() => _SessionListViewState();
+}
+
+class _SessionListViewState extends State<SessionListView> {
+  bool isCreating = false;
+
+  Future<void> createSession() async {
+    if (isCreating) {
+      return;
+    }
+
+    setState(() => isCreating = true);
+    try {
+      await widget.sessionRepository.createSession(
+        uid: widget.bootstrap.uid,
+        pcBridgeId: widget.bootstrap.pcBridgeId,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => isCreating = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<SessionSummary>>(
+      stream: widget.sessionRepository.watchSessions(widget.bootstrap.uid),
+      builder: (context, snapshot) {
+        final sessions = snapshot.data ?? const <SessionSummary>[];
+
+        return Stack(
+          children: [
+            RefreshIndicator(
+              onRefresh: () async {},
+              child: CustomScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                slivers: [
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                      child: _ConnectionSummary(bootstrap: widget.bootstrap),
+                    ),
+                  ),
+                  if (snapshot.connectionState == ConnectionState.waiting)
+                    const SliverFillRemaining(
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  else if (snapshot.hasError)
+                    SliverFillRemaining(
+                      child: _StartupMessage(
+                        title: 'Session load failed',
+                        message: snapshot.error.toString(),
+                        child: const Icon(Icons.error_outline, size: 36),
+                      ),
+                    )
+                  else if (sessions.isEmpty)
+                    const SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: _EmptySessions(),
+                    )
+                  else
+                    SliverList.builder(
+                      itemCount: sessions.length,
+                      itemBuilder: (context, index) {
+                        return _SessionTile(session: sessions[index]);
+                      },
+                    ),
+                ],
+              ),
+            ),
+            Positioned(
+              right: 20,
+              bottom: 20,
+              child: FloatingActionButton.extended(
+                onPressed: isCreating ? null : createSession,
+                icon: isCreating
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.add),
+                label: Text(isCreating ? 'Creating' : 'New session'),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ConnectionSummary extends StatelessWidget {
+  const _ConnectionSummary({required this.bootstrap});
+
+  final AppBootstrap bootstrap;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(14),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Connected as anonymous user', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text('PC bridge: ${bootstrap.pcBridgeId}'),
+            const SizedBox(height: 4),
+            SelectableText('UID: ${bootstrap.uid}'),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SessionTile extends StatelessWidget {
+  const _SessionTile({required this.session});
+
+  final SessionSummary session;
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = session.lastErrorPreview ?? session.lastResultPreview ?? session.status;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Card(
+        child: ListTile(
+          title: Text(session.title),
+          subtitle: Text(subtitle),
+          trailing: const Icon(Icons.chevron_right),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptySessions extends StatelessWidget {
+  const _EmptySessions();
 
   @override
   Widget build(BuildContext context) {
@@ -104,53 +344,10 @@ class _ReadyView extends StatelessWidget {
         padding: const EdgeInsets.all(24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            const Icon(Icons.check_circle_outline, size: 40),
-            const SizedBox(height: 20),
-            Text(
-              'RemoteCodex',
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Anonymous sign-in is ready.',
-              textAlign: TextAlign.center,
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 24),
-            _InfoRow(label: 'PC bridge', value: bootstrap.pcBridgeId),
-            const SizedBox(height: 12),
-            _InfoRow(label: 'User uid', value: bootstrap.uid),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  const _InfoRow({required this.label, required this.value});
-
-  final String label;
-  final String value;
-
-  @override
-  Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(label, style: Theme.of(context).textTheme.labelMedium),
-            const SizedBox(height: 4),
-            SelectableText(value),
+            const Icon(Icons.forum_outlined, size: 40),
+            const SizedBox(height: 16),
+            Text('No sessions yet', style: Theme.of(context).textTheme.titleLarge),
           ],
         ),
       ),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,20 +1,73 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:remote_codex/main.dart';
 
 void main() {
-  testWidgets('shows anonymous auth ready state', (tester) async {
+  testWidgets('shows empty session list after anonymous auth baseline', (tester) async {
+    final repository = FakeSessionRepository();
+
     await tester.pumpWidget(
       RemoteCodexApp(
         bootstrap: Future<AppBootstrap>.value(
           const AppBootstrap(uid: 'test-uid', pcBridgeId: defaultPcBridgeId),
         ),
+        sessionRepository: repository,
       ),
     );
     await tester.pump();
+    repository.emit(const <SessionSummary>[]);
+    await tester.pump();
 
-    expect(find.text('RemoteCodex'), findsWidgets);
-    expect(find.text('Anonymous sign-in is ready.'), findsOneWidget);
-    expect(find.text('home-main-pc'), findsOneWidget);
-    expect(find.text('test-uid'), findsOneWidget);
+    expect(find.text('Connected as anonymous user'), findsOneWidget);
+    expect(find.text('PC bridge: home-main-pc'), findsOneWidget);
+    expect(find.text('UID: test-uid'), findsOneWidget);
+    expect(find.text('No sessions yet'), findsOneWidget);
   });
+
+  testWidgets('creates a session from the floating action button', (tester) async {
+    final repository = FakeSessionRepository();
+
+    await tester.pumpWidget(
+      RemoteCodexApp(
+        bootstrap: Future<AppBootstrap>.value(
+          const AppBootstrap(uid: 'test-uid', pcBridgeId: defaultPcBridgeId),
+        ),
+        sessionRepository: repository,
+      ),
+    );
+    await tester.pump();
+    repository.emit(const <SessionSummary>[]);
+    await tester.pump();
+
+    await tester.tap(find.text('New session'));
+    await tester.pump();
+
+    expect(repository.createdSessionCount, 1);
+    expect(find.text('Session 1'), findsOneWidget);
+  });
+}
+
+class FakeSessionRepository implements SessionRepository {
+  final StreamController<List<SessionSummary>> controller = StreamController<List<SessionSummary>>.broadcast();
+  int createdSessionCount = 0;
+
+  void emit(List<SessionSummary> sessions) {
+    controller.add(sessions);
+  }
+
+  @override
+  Stream<List<SessionSummary>> watchSessions(String uid) => controller.stream;
+
+  @override
+  Future<void> createSession({required String uid, required String pcBridgeId}) async {
+    createdSessionCount++;
+    controller.add([
+      SessionSummary(
+        id: 'session-$createdSessionCount',
+        title: 'Session $createdSessionCount',
+        status: 'idle',
+      ),
+    ]);
+  }
 }


### PR DESCRIPTION
## Summary
- Add Firestore-backed session repository for `/users/{uid}/sessions`.
- Show authenticated connection details, empty session state, and existing sessions.
- Add `New session` action that creates an idle session targeting `home-main-pc`.
- Update README files with the current Phase 5 state.

Closes #35

## Verification
- flutter analyze
- flutter test
- flutter build apk --debug