### PR TITLE
fix: support Xperia Firebase startup validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Phase
 
-Phase 5 Android app MVP is in progress. Flutter scaffold, Firebase initialization, anonymous-auth baseline, session list/create, and command submission/result display are in place; Xperia 1 III validation remains.
+Phase 5 Android app MVP is in progress. Flutter scaffold, Firebase initialization, anonymous-auth baseline, session list/create, command submission/result display, and Xperia 1 III wireless debug launch are in place.
 
 ## Documents
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -9,17 +9,17 @@ const defaultPcBridgeId = 'home-main-pc';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  final firestore = FirebaseFirestore.instance;
   runApp(
     RemoteCodexApp(
-      bootstrap: bootstrapRemoteCodex(firestore),
-      sessionRepository: FirestoreSessionRepository(firestore),
+      bootstrap: bootstrapRemoteCodex(),
+      sessionRepository: FirestoreSessionRepository(),
     ),
   );
 }
 
-Future<AppBootstrap> bootstrapRemoteCodex(FirebaseFirestore firestore) async {
+Future<AppBootstrap> bootstrapRemoteCodex() async {
   await Firebase.initializeApp();
+  final firestore = FirebaseFirestore.instance;
 
   final credential = await FirebaseAuth.instance.signInAnonymously();
   final uid = credential.user?.uid;
@@ -90,9 +90,11 @@ abstract class SessionRepository {
 }
 
 class FirestoreSessionRepository implements SessionRepository {
-  FirestoreSessionRepository(this.firestore);
+  FirestoreSessionRepository([FirebaseFirestore? firestore]) : _firestore = firestore;
 
-  final FirebaseFirestore firestore;
+  final FirebaseFirestore? _firestore;
+
+  FirebaseFirestore get firestore => _firestore ?? FirebaseFirestore.instance;
 
   @override
   Stream<List<SessionSummary>> watchSessions(String uid) {

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -128,6 +128,29 @@ Phase 5開始前の再確認:
 SO 51B (mobile) • 192.168.0.4:44283 • android-arm64 • Android 13 (API 33)
 ```
 
+Phase 5実機確認:
+
+```text
+SO 51B (mobile) • 192.168.0.4:39757 • android-arm64 • Android 13 (API 33)
+```
+
+確認済み:
+
+- `flutter run -d 192.168.0.4:39757 --debug --no-resident` でXperia 1 IIIへDebug APKをインストール、起動。
+- アプリ起動時のFirebase初期化順序を修正し、`Firebase.initializeApp()` 後にFirestoreを参照する形へ変更。
+- Firestore rulesを `firebase deploy --only firestore:rules` で実プロジェクト `remotecodex-c52ae` へデプロイ。
+- Xperia 1 III画面で匿名認証後のセッション一覧初期画面を確認。
+- 画面に表示されたUIDをPCブリッジのローカル `ownerUserId` に設定し、PCブリッジがFirestore接続で `No queued command found.` まで到達することを確認。
+
+residentのhot reloadは次のように起動して、変更後に `r` を押して確認する。
+
+```powershell
+Set-Location app
+flutter run -d 192.168.0.4:39757 --debug
+```
+
+終了は `q`。ワイヤレスデバッグのポートは変わるため、接続できない場合はXperia側の現在のdebug-portを確認し直す。
+
 ### 前提
 
 - PCとXperia 1 IIIが同じ自宅WiFiルーター配下にいる。


### PR DESCRIPTION
## Summary
- Fix app startup order so Firestore is accessed only after `Firebase.initializeApp()`.
- Document Xperia 1 III wireless debug validation and Firestore rules deployment.
- Record the local PC bridge `ownerUserId` handoff needed after anonymous auth.

Refs #37

## Verification
- flutter analyze
- flutter test
- flutter run -d 192.168.0.4:39757 --debug --no-resident
- firebase deploy --only firestore:rules
- PC bridge `npm.cmd run start` reaches `No queued command found.` with ownerUserId set locally

## Remaining for #37
- Manual resident hot reload confirmation with `flutter run -d 192.168.0.4:39757 --debug`, then pressing `r` after a small UI change.