### PR TITLE
Add Android FCM token registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Setup Status
 
-- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, shows sessions, and can queue text commands for the PC bridge.
+- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, and can queue text commands for the PC bridge.
 - `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can reach Firebase in `stub` mode.
 - `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules and command query index.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.
 
 ## Current Phase
 
-Phase 5 Android app MVP is in progress. Flutter scaffold, Firebase initialization, anonymous-auth baseline, session list/create, command submission/result display, Xperia 1 III wireless debug launch, and manual hot reload validation are in place.
+Phase 6 push notification integration is in progress. Android FCM setup and device token storage are being added before the Cloud Functions notification trigger.
 
 ## Documents
 

--- a/app/README.md
+++ b/app/README.md
@@ -27,12 +27,20 @@ Firebase SDK設定で、ユーザーが取得した `google-services.json` を `
 1. `Firebase.initializeApp()`
 2. Firebase Anonymous Authの `signInAnonymously()`
 3. `/users/{uid}` へMVP接続先 `home-main-pc` を保存
+4. FCM通知権限を要求し、`/users/{uid}/devices/android-app` へFCM tokenを保存
 
 初回実機起動後、画面に表示される `User uid` をPCブリッジの `config.local.json` の `ownerUserId` に設定すると、PCブリッジのheartbeatを `/users/{uid}/pcBridges/home-main-pc` に保存できる。
 
 セッション一覧では `/users/{uid}/sessions` を `updatedAt` 降順で購読し、`New session` から新規セッションを作成する。作成時はMVP接続先として `targetPcBridgeId: home-main-pc` を保存する。
 
 セッション詳細では `/users/{uid}/sessions/{sessionId}/commands` を `createdAt` 降順で購読し、入力したテキストを `queued` コマンドとして作成する。処理中の逐次ログは表示せず、Firestoreに保存された `resultText` または `errorText` を最終結果として表示する。
+
+通知設定:
+
+- Android 13+向けに `POST_NOTIFICATIONS` 権限を宣言。
+- FCM tokenを起動時とtoken refresh時に保存。
+- Android notification channel `remote_codex_completion` を作成。
+- foregroundでFCMを受けた場合はlocal notificationとして表示する。
 
 ## MVP責務
 

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -14,6 +14,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 }

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:label="RemoteCodex"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="remote_codex_completion" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -3,12 +3,23 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 const defaultPcBridgeId = 'home-main-pc';
+const androidDeviceId = 'android-app';
+const notificationChannelId = 'remote_codex_completion';
+const notificationChannelName = 'RemoteCodex completion';
+
+@pragma('vm:entry-point')
+Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+}
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+  FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
   runApp(
     RemoteCodexApp(
       bootstrap: bootstrapRemoteCodex(),
@@ -35,14 +46,145 @@ Future<AppBootstrap> bootstrapRemoteCodex() async {
     'lastSignedInAt': FieldValue.serverTimestamp(),
   }, SetOptions(merge: true));
 
-  return AppBootstrap(uid: uid, pcBridgeId: defaultPcBridgeId);
+  final notificationState = await NotificationService().registerDevice(
+    uid: uid,
+    firestore: firestore,
+  );
+
+  return AppBootstrap(
+    uid: uid,
+    pcBridgeId: defaultPcBridgeId,
+    notificationState: notificationState,
+  );
 }
 
 class AppBootstrap {
-  const AppBootstrap({required this.uid, required this.pcBridgeId});
+  const AppBootstrap({
+    required this.uid,
+    required this.pcBridgeId,
+    required this.notificationState,
+  });
 
   final String uid;
   final String pcBridgeId;
+  final NotificationState notificationState;
+}
+
+class NotificationState {
+  const NotificationState({
+    required this.permissionStatus,
+    required this.hasToken,
+  });
+
+  final String permissionStatus;
+  final bool hasToken;
+}
+
+class NotificationService {
+  factory NotificationService() => _instance;
+
+  NotificationService._();
+
+  static final NotificationService _instance = NotificationService._();
+  static final FlutterLocalNotificationsPlugin _localNotifications = FlutterLocalNotificationsPlugin();
+  static bool _initialized = false;
+
+  Future<NotificationState> registerDevice({
+    required String uid,
+    required FirebaseFirestore firestore,
+  }) async {
+    await _initializeLocalNotifications();
+
+    final messaging = FirebaseMessaging.instance;
+    final settings = await messaging.requestPermission();
+    final token = await messaging.getToken();
+
+    await _storeToken(
+      firestore: firestore,
+      uid: uid,
+      token: token,
+      permissionStatus: settings.authorizationStatus.name,
+    );
+
+    FirebaseMessaging.instance.onTokenRefresh.listen((newToken) {
+      _storeToken(
+        firestore: firestore,
+        uid: uid,
+        token: newToken,
+        permissionStatus: settings.authorizationStatus.name,
+      );
+    });
+
+    FirebaseMessaging.onMessage.listen(_showForegroundNotification);
+
+    return NotificationState(
+      permissionStatus: settings.authorizationStatus.name,
+      hasToken: token != null && token.isNotEmpty,
+    );
+  }
+
+  Future<void> _initializeLocalNotifications() async {
+    if (_initialized) {
+      return;
+    }
+
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+    );
+    await _localNotifications.initialize(settings: initializationSettings);
+
+    const channel = AndroidNotificationChannel(
+      notificationChannelId,
+      notificationChannelName,
+      description: 'Notifications for completed or failed remote Codex commands.',
+      importance: Importance.high,
+    );
+
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(channel);
+
+    _initialized = true;
+  }
+
+  Future<void> _storeToken({
+    required FirebaseFirestore firestore,
+    required String uid,
+    required String? token,
+    required String permissionStatus,
+  }) async {
+    await firestore.collection('users').doc(uid).collection('devices').doc(androidDeviceId).set({
+      'deviceId': androidDeviceId,
+      'platform': 'android',
+      'fcmToken': token,
+      'notificationPermission': permissionStatus,
+      'updatedAt': FieldValue.serverTimestamp(),
+    }, SetOptions(merge: true));
+  }
+
+  Future<void> _showForegroundNotification(RemoteMessage message) async {
+    final notification = message.notification;
+    final title = notification?.title ?? 'RemoteCodex';
+    final body = notification?.body ?? 'Remote processing finished.';
+
+    const details = NotificationDetails(
+      android: AndroidNotificationDetails(
+        notificationChannelId,
+        notificationChannelName,
+        channelDescription: 'Notifications for completed or failed remote Codex commands.',
+        importance: Importance.high,
+        priority: Priority.high,
+      ),
+    );
+
+    await _localNotifications.show(
+      id: message.hashCode,
+      title: title,
+      body: body,
+      notificationDetails: details,
+      payload: message.data['sessionId'] as String?,
+    );
+  }
 }
 
 class SessionSummary {
@@ -397,6 +539,8 @@ class _ConnectionSummary extends StatelessWidget {
             Text('Connected as anonymous user', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
             Text('PC bridge: ${bootstrap.pcBridgeId}'),
+            const SizedBox(height: 4),
+            Text('Notifications: ${bootstrap.notificationState.permissionStatus}'),
             const SizedBox(height: 4),
             SelectableText('UID: ${bootstrap.uid}'),
           ],

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.69"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -81,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -89,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -137,6 +161,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.6.0"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: e5c93e8e7a9b0513f94bb684d2cf100e32e7dcdf2949574386b1955fc9a9b96a
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.2.0"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "8cbb7d842e5071bba836452aff262f7db4b14bb3a0d00c1896cf176df886d65a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.9"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "8750bacf50573c0383535fc3f9c58c6a2f9dff5320a16a82c30631b9dad894f1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.5"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -150,6 +198,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "21.0.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -240,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -301,6 +389,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:
@@ -333,6 +429,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.22.0"
+  flutter: ">=3.38.1"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   firebase_core: ^4.7.0
   firebase_auth: ^6.4.0
   cloud_firestore: ^6.3.0
+  firebase_messaging: ^16.2.0
+  flutter_local_notifications: ^21.0.0
 
 dev_dependencies:
   flutter_test:

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -11,7 +11,11 @@ void main() {
     await tester.pumpWidget(
       RemoteCodexApp(
         bootstrap: Future<AppBootstrap>.value(
-          const AppBootstrap(uid: 'test-uid', pcBridgeId: defaultPcBridgeId),
+          const AppBootstrap(
+            uid: 'test-uid',
+            pcBridgeId: defaultPcBridgeId,
+            notificationState: NotificationState(permissionStatus: 'authorized', hasToken: true),
+          ),
         ),
         sessionRepository: repository,
       ),
@@ -32,7 +36,11 @@ void main() {
     await tester.pumpWidget(
       RemoteCodexApp(
         bootstrap: Future<AppBootstrap>.value(
-          const AppBootstrap(uid: 'test-uid', pcBridgeId: defaultPcBridgeId),
+          const AppBootstrap(
+            uid: 'test-uid',
+            pcBridgeId: defaultPcBridgeId,
+            notificationState: NotificationState(permissionStatus: 'authorized', hasToken: true),
+          ),
         ),
         sessionRepository: repository,
       ),
@@ -54,7 +62,11 @@ void main() {
     await tester.pumpWidget(
       RemoteCodexApp(
         bootstrap: Future<AppBootstrap>.value(
-          const AppBootstrap(uid: 'test-uid', pcBridgeId: defaultPcBridgeId),
+          const AppBootstrap(
+            uid: 'test-uid',
+            pcBridgeId: defaultPcBridgeId,
+            notificationState: NotificationState(permissionStatus: 'authorized', hasToken: true),
+          ),
         ),
         sessionRepository: repository,
       ),


### PR DESCRIPTION
## Summary
- Add Firebase Messaging and Android notification channel setup to the Flutter app.
- Request Android notification permission and register the device FCM token under the signed-in user's Firestore device document.
- Refresh token storage on FCM token changes and show foreground completion notifications through a local notification channel.
- Update README/app docs for current Phase 6 behavior.

Closes #45
Closes #46

## Verification
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug`
- `flutter run -d 192.168.0.4:39757 --debug --no-resident`
- Firestore device document verified for the Xperia user with a token present; token value was not printed.
- `npm.cmd run start` in `pc-bridge` after local owner UID correction.