### PR TITLE
Add command completion notification function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 - `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, and can queue text commands for the PC bridge.
 - `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can reach Firebase in `stub` mode.
-- `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules and command query index.
+- `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules, command query index, and a Cloud Function that sends FCM completion notifications.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.
 
 ## Current Phase
 
-Phase 6 push notification integration is in progress. Android FCM setup and device token storage are being added before the Cloud Functions notification trigger.
+Phase 6 push notification integration is in progress. Android FCM setup and device token storage are complete, and the Cloud Functions completion notification trigger builds locally. Functions deployment is blocked until Firebase project `remotecodex-c52ae` is upgraded to the Blaze plan.
 
 ## Documents
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -10,19 +10,21 @@ MVPで使うFirebase機能:
 - Cloud Functions
 - Firebase Emulator Suite
 
-Phase 3時点ではFirebase CLIがPATH上にないため、実際の `firebase init` は未実施。
+Firebase CLIは導入済みで、Firebase project `remotecodex-c52ae` に紐づけ済み。
+Firestore rules / indexes はデプロイ済みで、Phase 6ではFunctionsの実装とデプロイを進める。
+Cloud Functions のデプロイには Blaze plan が必要なため、`remotecodex-c52ae` のプラン更新後にデプロイする。
 
-Firebase CLI導入後、Phase 3またはPhase 6で次を実施する。
+Firebase設定を更新した場合は、次を実行して対象projectを確認する。
 
 ```powershell
-firebase login
-firebase init firestore functions emulators
+firebase use
+firebase deploy --only firestore:rules,firestore:indexes
 ```
 
 ## ファイル
 
-- `firebase.json`: EmulatorとFirestore/Functions設定の初期案。
-- `firestore.rules`: MVP Security Rulesの初期雛形。
-- `firestore.indexes.json`: Firestore indexesの初期雛形。
+- `firebase.json`: EmulatorとFirestore/Functions設定。
+- `firestore.rules`: MVP Security Rules。
+- `firestore.indexes.json`: Firestore command query index。
 - `functions/`: 通知Cloud Functionsの配置先。
 

--- a/firebase/functions/README.md
+++ b/firebase/functions/README.md
@@ -9,3 +9,19 @@ Phase 6で実装する主な処理:
 - FCM通知を送信する。
 - `notificationSentAt` を更新して二重通知を防ぐ。
 
+## 実装メモ
+
+- トリガー: `users/{userId}/sessions/{sessionId}/commands/{commandId}` の更新。
+- 対象ステータス: `completed` / `failed` への遷移のみ。
+- 通知channel: Android側の `remote_codex_completion` と合わせる。
+- payload: `type`, `userId`, `sessionId`, `commandId`, `status` の最小構成。
+- 通知本文: `resultText` または `errorText` の先頭120文字を1行に整形する。
+
+## 検証
+
+```powershell
+npm.cmd run build
+firebase deploy --only functions
+```
+
+`firebase deploy --only functions` は Blaze plan が必要。Spark plan のままでは `artifactregistry.googleapis.com` / `cloudbuild.googleapis.com` を有効化できず停止する。

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -1,2 +1,108 @@
-export const scaffold = "Phase 6 will implement completion notification functions.";
+import { initializeApp } from "firebase-admin/app";
+import { FieldValue, getFirestore, Timestamp, type DocumentData } from "firebase-admin/firestore";
+import { getMessaging } from "firebase-admin/messaging";
+import { logger } from "firebase-functions";
+import { onDocumentUpdated } from "firebase-functions/v2/firestore";
 
+initializeApp();
+
+const terminalStatuses = new Set(["completed", "failed"]);
+const notificationChannelId = "remote_codex_completion";
+
+export const notifyCommandCompletion = onDocumentUpdated(
+  "users/{userId}/sessions/{sessionId}/commands/{commandId}",
+  async (event) => {
+    const change = event.data;
+    if (!change) {
+      return;
+    }
+
+    const before = change.before.data();
+    const after = change.after.data();
+
+    const status = String(after.status ?? "");
+    if (!terminalStatuses.has(status) || before.status === after.status || after.notificationSentAt) {
+      return;
+    }
+
+    const { userId, sessionId, commandId } = event.params;
+    const firestore = getFirestore();
+    const devices = await firestore.collection(`users/${userId}/devices`).get();
+    const tokens = devices.docs
+      .map((device) => device.data().fcmToken)
+      .filter((token): token is string => typeof token === "string" && token.length > 0);
+
+    if (tokens.length === 0) {
+      logger.info("No FCM tokens found for completed command.", { userId, sessionId, commandId });
+      return;
+    }
+
+    const message = buildCompletionMessage(status, after, sessionId, commandId);
+    const response = await getMessaging().sendEachForMulticast({
+      tokens,
+      notification: {
+        title: message.title,
+        body: message.body,
+      },
+      android: {
+        notification: {
+          channelId: notificationChannelId,
+          clickAction: "FLUTTER_NOTIFICATION_CLICK",
+        },
+      },
+      data: {
+        type: "commandCompletion",
+        userId,
+        sessionId,
+        commandId,
+        status,
+      },
+    });
+
+    await change.after.ref.update({
+      notificationSentAt: Timestamp.now(),
+      notificationSuccessCount: response.successCount,
+      notificationFailureCount: response.failureCount,
+      notificationLastError: firstErrorCode(response.responses) ?? FieldValue.delete(),
+    });
+
+    logger.info("Sent command completion notification.", {
+      userId,
+      sessionId,
+      commandId,
+      status,
+      successCount: response.successCount,
+      failureCount: response.failureCount,
+    });
+  },
+);
+
+type CompletionMessage = {
+  title: string;
+  body: string;
+};
+
+function buildCompletionMessage(status: string, command: DocumentData, sessionId: string, commandId: string): CompletionMessage {
+  const isCompleted = status === "completed";
+  const previewSource = isCompleted ? command.resultText : command.errorText;
+  const preview = compactPreview(previewSource);
+
+  return {
+    title: isCompleted ? "RemoteCodex completed" : "RemoteCodex failed",
+    body: preview || `Session ${sessionId}, command ${commandId}`,
+  };
+}
+
+function compactPreview(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  const oneLine = value.replace(/\s+/g, " ").trim();
+  return oneLine.length <= 120 ? oneLine : `${oneLine.slice(0, 117)}...`;
+}
+
+function firstErrorCode(responses: Array<{ error?: { code?: string } }>): string | null {
+  const failed = responses.find((response) => response.error?.code);
+  return failed?.error?.code ?? null;
+}


### PR DESCRIPTION
## Summary
- Add `notifyCommandCompletion`, a Firestore update trigger for completed/failed command documents.
- Send FCM notifications to registered user device tokens with minimal routing payload.
- Store notification send metadata on the command document to avoid duplicate notification work.
- Update README/Firebase docs with the current Phase 6 status and Blaze-plan deployment blocker.

Related #47
Related #51

## Verification
- `npm.cmd run build` in `firebase/functions`
- `firebase deploy --only functions` attempted from `firebase/`, blocked because project `remotecodex-c52ae` must be upgraded to Blaze before Artifact Registry / Cloud Build APIs can be enabled.

## Deployment Status
Not deployed yet. #47 remains open until Functions deployment and real FCM delivery are verified after #51 is completed.