### PR TITLE
Route notification taps to sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Setup Status
 
-- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, and can queue text commands for the PC bridge.
+- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, queues text commands for the PC bridge, and routes notification taps to the target session.
 - `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can reach Firebase in `stub` mode.
 - `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules, command query index, and a Cloud Function that sends FCM completion notifications.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.

--- a/app/README.md
+++ b/app/README.md
@@ -21,6 +21,8 @@ Firebase SDK設定で、ユーザーが取得した `google-services.json` を `
 - `firebase_core`
 - `firebase_auth`
 - `cloud_firestore`
+- `firebase_messaging`
+- `flutter_local_notifications`
 
 起動時に次を実行する。
 
@@ -41,6 +43,7 @@ Firebase SDK設定で、ユーザーが取得した `google-services.json` を `
 - FCM tokenを起動時とtoken refresh時に保存。
 - Android notification channel `remote_codex_completion` を作成。
 - foregroundでFCMを受けた場合はlocal notificationとして表示する。
+- foreground local notificationまたはbackground/terminated状態のFCM通知をタップした場合、payloadの `sessionId` に対応するセッション詳細へ遷移する。
 
 ## MVP責務
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -11,6 +12,7 @@ const defaultPcBridgeId = 'home-main-pc';
 const androidDeviceId = 'android-app';
 const notificationChannelId = 'remote_codex_completion';
 const notificationChannelName = 'RemoteCodex completion';
+final appNavigatorKey = GlobalKey<NavigatorState>();
 
 @pragma('vm:entry-point')
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
@@ -88,6 +90,10 @@ class NotificationService {
   static final NotificationService _instance = NotificationService._();
   static final FlutterLocalNotificationsPlugin _localNotifications = FlutterLocalNotificationsPlugin();
   static bool _initialized = false;
+  static bool _messageHandlersRegistered = false;
+  AppBootstrap? _bootstrap;
+  SessionRepository? _sessionRepository;
+  String? _pendingSessionId;
 
   Future<NotificationState> registerDevice({
     required String uid,
@@ -115,12 +121,26 @@ class NotificationService {
       );
     });
 
-    FirebaseMessaging.onMessage.listen(_showForegroundNotification);
+    _registerMessageHandlers();
 
     return NotificationState(
       permissionStatus: settings.authorizationStatus.name,
       hasToken: token != null && token.isNotEmpty,
     );
+  }
+
+  void attachNavigation({
+    required AppBootstrap bootstrap,
+    required SessionRepository sessionRepository,
+  }) {
+    _bootstrap = bootstrap;
+    _sessionRepository = sessionRepository;
+
+    final pendingSessionId = _pendingSessionId;
+    if (pendingSessionId != null) {
+      _pendingSessionId = null;
+      scheduleMicrotask(() => _openSession(pendingSessionId));
+    }
   }
 
   Future<void> _initializeLocalNotifications() async {
@@ -131,7 +151,15 @@ class NotificationService {
     const initializationSettings = InitializationSettings(
       android: AndroidInitializationSettings('@mipmap/ic_launcher'),
     );
-    await _localNotifications.initialize(settings: initializationSettings);
+    await _localNotifications.initialize(
+      settings: initializationSettings,
+      onDidReceiveNotificationResponse: (response) {
+        final sessionId = sessionIdFromPayload(response.payload);
+        if (sessionId != null) {
+          _openSession(sessionId);
+        }
+      },
+    );
 
     const channel = AndroidNotificationChannel(
       notificationChannelId,
@@ -145,6 +173,29 @@ class NotificationService {
         ?.createNotificationChannel(channel);
 
     _initialized = true;
+  }
+
+  void _registerMessageHandlers() {
+    if (_messageHandlersRegistered) {
+      return;
+    }
+
+    FirebaseMessaging.onMessage.listen(_showForegroundNotification);
+    FirebaseMessaging.onMessageOpenedApp.listen((message) {
+      final sessionId = sessionIdFromMessageData(message.data);
+      if (sessionId != null) {
+        _openSession(sessionId);
+      }
+    });
+
+    FirebaseMessaging.instance.getInitialMessage().then((message) {
+      final sessionId = message == null ? null : sessionIdFromMessageData(message.data);
+      if (sessionId != null) {
+        _openSession(sessionId);
+      }
+    });
+
+    _messageHandlersRegistered = true;
   }
 
   Future<void> _storeToken({
@@ -182,9 +233,72 @@ class NotificationService {
       title: title,
       body: body,
       notificationDetails: details,
-      payload: message.data['sessionId'] as String?,
+      payload: notificationPayloadFromMessageData(message.data),
     );
   }
+
+  void _openSession(String sessionId) {
+    final navigator = appNavigatorKey.currentState;
+    final bootstrap = _bootstrap;
+    final sessionRepository = _sessionRepository;
+
+    if (navigator == null || bootstrap == null || sessionRepository == null) {
+      _pendingSessionId = sessionId;
+      return;
+    }
+
+    navigator.push(
+      MaterialPageRoute<void>(
+        builder: (_) => SessionDetailPage(
+          bootstrap: bootstrap,
+          session: SessionSummary(
+            id: sessionId,
+            title: 'Session $sessionId',
+            status: 'unknown',
+          ),
+          sessionRepository: sessionRepository,
+        ),
+      ),
+    );
+  }
+}
+
+String notificationPayloadFromMessageData(Map<String, dynamic> data) {
+  return jsonEncode({
+    'sessionId': data['sessionId'],
+    'commandId': data['commandId'],
+    'status': data['status'],
+  });
+}
+
+String? sessionIdFromPayload(String? payload) {
+  if (payload == null || payload.trim().isEmpty) {
+    return null;
+  }
+
+  try {
+    final decoded = jsonDecode(payload);
+    if (decoded is Map<String, dynamic>) {
+      return nonEmptyString(decoded['sessionId']);
+    }
+  } on FormatException {
+    return payload.trim();
+  }
+
+  return null;
+}
+
+String? sessionIdFromMessageData(Map<String, dynamic> data) {
+  return nonEmptyString(data['sessionId']);
+}
+
+String? nonEmptyString(Object? value) {
+  if (value is! String) {
+    return null;
+  }
+
+  final trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
 }
 
 class SessionSummary {
@@ -344,6 +458,7 @@ class RemoteCodexApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      navigatorKey: appNavigatorKey,
       title: 'RemoteCodex',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2563EB)),
@@ -418,6 +533,15 @@ class SessionListView extends StatefulWidget {
 
 class _SessionListViewState extends State<SessionListView> {
   bool isCreating = false;
+
+  @override
+  void initState() {
+    super.initState();
+    NotificationService().attachNavigation(
+      bootstrap: widget.bootstrap,
+      sessionRepository: widget.sessionRepository,
+    );
+  }
 
   Future<void> createSession() async {
     if (isCreating) {

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -5,6 +5,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:remote_codex/main.dart';
 
 void main() {
+  test('parses notification routing payloads', () {
+    final payload = notificationPayloadFromMessageData({
+      'sessionId': 'session-1',
+      'commandId': 'command-1',
+      'status': 'completed',
+    });
+
+    expect(sessionIdFromPayload(payload), 'session-1');
+    expect(sessionIdFromPayload('legacy-session'), 'legacy-session');
+    expect(sessionIdFromPayload(''), isNull);
+    expect(sessionIdFromMessageData({'sessionId': 'session-2'}), 'session-2');
+  });
+
   testWidgets('shows empty session list after anonymous auth baseline', (tester) async {
     final repository = FakeSessionRepository();
 


### PR DESCRIPTION
## Summary
- Add notification tap routing for foreground local notifications and background/terminated FCM opens.
- Preserve pending notification routing until the app has bootstrap/session repository context.
- Encode notification payloads with session, command, and status fields while keeping legacy raw session payload parsing.
- Update app and root README status.

Closes #48

## Verification
- `D:\tools\flutter\bin\flutter.bat analyze`
- `D:\tools\flutter\bin\flutter.bat test`
- `D:\tools\flutter\bin\flutter.bat build apk --debug`
- `D:\tools\flutter\bin\flutter.bat run -d 192.168.0.4:39757 --debug --no-resident`