### PR TITLE
Prepare Functions deployment build

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Phase
 
-Phase 6 push notification integration is in progress. Android FCM setup and device token storage are complete, and the Cloud Functions completion notification trigger builds locally. Functions deployment is blocked until Firebase project `remotecodex-c52ae` is upgraded to the Blaze plan.
+Phase 6 push notification integration is in progress. Android FCM setup, device token storage, notification tap routing, and the Cloud Functions completion notification trigger are implemented. Functions deployment is blocked until Compute Engine API is enabled for Firebase project `remotecodex-c52ae`.
 
 ## Documents
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -12,7 +12,8 @@ MVPで使うFirebase機能:
 
 Firebase CLIは導入済みで、Firebase project `remotecodex-c52ae` に紐づけ済み。
 Firestore rules / indexes はデプロイ済みで、Phase 6ではFunctionsの実装とデプロイを進める。
-Cloud Functions のデプロイには Blaze plan が必要なため、`remotecodex-c52ae` のプラン更新後にデプロイする。
+Cloud Functions のデプロイには Blaze plan と、初回デプロイ時に要求されるGoogle Cloud APIの有効化が必要。
+`remotecodex-c52ae` はBlaze planへ更新済みだが、現時点ではCompute Engine APIが無効なためFunctions upload bucketの作成で停止している。
 
 Firebase設定を更新した場合は、次を実行して対象projectを確認する。
 

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -4,7 +4,10 @@
     "indexes": "firestore.indexes.json"
   },
   "functions": {
-    "source": "functions"
+    "source": "functions",
+    "predeploy": [
+      "npm --prefix \"$RESOURCE_DIR\" run build"
+    ]
   },
   "emulators": {
     "auth": {

--- a/firebase/functions/README.md
+++ b/firebase/functions/README.md
@@ -21,7 +21,14 @@ Phase 6で実装する主な処理:
 
 ```powershell
 npm.cmd run build
+npm.cmd run check
 firebase deploy --only functions
 ```
 
-`firebase deploy --only functions` は Blaze plan が必要。Spark plan のままでは `artifactregistry.googleapis.com` / `cloudbuild.googleapis.com` を有効化できず停止する。
+`firebase deploy --only functions` は事前に `npm --prefix "$RESOURCE_DIR" run build` を実行し、`lib/index.js` を生成する。
+
+初回デプロイ時の注意:
+
+- Blaze plan が必要。
+- Cloud Functions / Cloud Build / Artifact Registry / Cloud Run / Eventarc / Pub/Sub / Compute Engine API が必要。
+- 現在はCompute Engine APIが無効なため、Functions upload bucket作成時に `Could not create bucket ... PERMISSION_DENIED` で停止している。

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "Firebase Cloud Functions for Codex Remote Android.",
   "type": "module",
+  "main": "lib/index.js",
   "scripts": {
-    "build": "tsc --noEmit",
+    "build": "tsc",
     "check": "tsc --noEmit"
   },
   "dependencies": {

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -10,7 +10,10 @@ const terminalStatuses = new Set(["completed", "failed"]);
 const notificationChannelId = "remote_codex_completion";
 
 export const notifyCommandCompletion = onDocumentUpdated(
-  "users/{userId}/sessions/{sessionId}/commands/{commandId}",
+  {
+    document: "users/{userId}/sessions/{sessionId}/commands/{commandId}",
+    region: "asia-northeast1",
+  },
   async (event) => {
     const change = event.data;
     if (!change) {


### PR DESCRIPTION
## Summary
- Configure Functions `main` and `build` so deploy emits `lib/index.js`.
- Add Firebase predeploy build step for Functions.
- Set `notifyCommandCompletion` region to `asia-northeast1` to match the Firestore location.
- Update README/Firebase docs with the current Compute Engine API deployment blocker.

Related #47
Related #54

## Verification
- `npm.cmd run check` in `firebase/functions`
- `npm.cmd run build` in `firebase/functions`
- `firebase deploy --only functions` attempted after Blaze upgrade; it now reaches function upload preparation, then stops because Compute Engine API is disabled and the Gen 2 upload bucket cannot be created.

## Deployment Status
Not deployed yet. Continue after #54 is completed.