### PR TITLE
Record Functions deployment validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Phase
 
-Phase 6 push notification integration is in progress. Android FCM setup, device token storage, notification tap routing, and the Cloud Functions completion notification trigger are implemented. Functions deployment is blocked until Compute Engine API is enabled for Firebase project `remotecodex-c52ae`.
+Phase 6 push notification integration is in progress. Android FCM setup, device token storage, notification tap routing, and the Cloud Functions completion notification trigger are implemented. `notifyCommandCompletion` is deployed to `asia-northeast1` and has sent a completion notification successfully in Firebase-side validation.
 
 ## Documents
 

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -11,15 +11,16 @@ MVPで使うFirebase機能:
 - Firebase Emulator Suite
 
 Firebase CLIは導入済みで、Firebase project `remotecodex-c52ae` に紐づけ済み。
-Firestore rules / indexes はデプロイ済みで、Phase 6ではFunctionsの実装とデプロイを進める。
-Cloud Functions のデプロイには Blaze plan と、初回デプロイ時に要求されるGoogle Cloud APIの有効化が必要。
-`remotecodex-c52ae` はBlaze planへ更新済みだが、現時点ではCompute Engine APIが無効なためFunctions upload bucketの作成で停止している。
+Firestore rules / indexes はデプロイ済み。
+Cloud Functions の `notifyCommandCompletion` は `asia-northeast1` にデプロイ済み。
+Blaze plan と初回デプロイ時に要求されるGoogle Cloud APIは有効化済み。
 
 Firebase設定を更新した場合は、次を実行して対象projectを確認する。
 
 ```powershell
 firebase use
 firebase deploy --only firestore:rules,firestore:indexes
+firebase deploy --only functions
 ```
 
 ## ファイル

--- a/firebase/functions/README.md
+++ b/firebase/functions/README.md
@@ -31,4 +31,13 @@ firebase deploy --only functions
 
 - Blaze plan が必要。
 - Cloud Functions / Cloud Build / Artifact Registry / Cloud Run / Eventarc / Pub/Sub / Compute Engine API が必要。
-- 現在はCompute Engine APIが無効なため、Functions upload bucket作成時に `Could not create bucket ... PERMISSION_DENIED` で停止している。
+- 初回の2nd gen FunctionsデプロイではEventarc権限反映に数分かかる場合がある。その場合は数分待って `firebase deploy --only functions` を再実行する。
+- Artifact RegistryのCloud Functions imageには7日保持のcleanup policyを設定済み。
+
+## デプロイ済み関数
+
+- `notifyCommandCompletion`
+- version: v2
+- region: `asia-northeast1`
+- runtime: `nodejs22`
+- trigger: `google.cloud.firestore.document.v1.updated`


### PR DESCRIPTION
## Summary
- Update root/Firebase docs to reflect that `notifyCommandCompletion` is deployed in `asia-northeast1`.
- Record that required Google Cloud APIs are enabled.
- Document first-time 2nd gen Functions/Eventarc propagation behavior and Artifact Registry cleanup policy.

Related #47
Related #49

## Verification
- `npm.cmd run check` in `firebase/functions`
- `npm.cmd run build` in `firebase/functions`
- `firebase deploy --only functions`
- `firebase functions:artifacts:setpolicy --location asia-northeast1 --days 7 --force`
- `firebase functions:list`
- Firestore validation command processed through PC bridge stub mode; command document showed `notificationSentAt`, `notificationSuccessCount: 1`, and `notificationFailureCount: 0`.