### PR TITLE
Add on-demand bridge health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Setup Status
 
-- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, queues text commands for the PC bridge, shows running progress logs, routes notification taps to the target session, and uses the custom RemoteCodex launcher icon.
-- `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can run `codexMode: cli` with a fixed Codex model, return 1-minute progress logs while Codex CLI is running, follow Android anonymous UID changes for bridge status, and `start:watch` can keep polling queued commands. Windows batch files under `pc-bridge/scripts/` can run the watcher in the background or register it with Task Scheduler.
+- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, queues text commands for the PC bridge, shows running progress logs, can request an on-demand PC bridge health check, routes notification taps to the target session, and uses the custom RemoteCodex launcher icon.
+- `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can run `codexMode: cli` with a fixed Codex model, return 1-minute progress logs while Codex CLI is running, respond to on-demand health checks, follow Android anonymous UID changes for bridge status, and `start:watch` can keep polling queued commands. Windows batch files under `pc-bridge/scripts/` can run the watcher in the background or register it with Task Scheduler.
 - `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules, command query index, and a Cloud Function that sends FCM completion notifications.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -356,10 +356,20 @@ class CommandSummary {
 }
 
 class PcBridgeStatus {
-  const PcBridgeStatus({this.lastSeenAt, this.lastQueueCheckedAt, this.status});
+  const PcBridgeStatus({
+    this.lastSeenAt,
+    this.lastQueueCheckedAt,
+    this.lastHealthCheckRequestedAt,
+    this.lastHealthCheckRespondedAt,
+    this.lastHealthCheckStatus,
+    this.status,
+  });
 
   final DateTime? lastSeenAt;
   final DateTime? lastQueueCheckedAt;
+  final DateTime? lastHealthCheckRequestedAt;
+  final DateTime? lastHealthCheckRespondedAt;
+  final String? lastHealthCheckStatus;
   final String? status;
 }
 
@@ -367,6 +377,10 @@ abstract class SessionRepository {
   Stream<List<SessionSummary>> watchSessions(String uid);
   Stream<List<CommandSummary>> watchCommands(String uid, String sessionId);
   Stream<PcBridgeStatus> watchPcBridgeStatus(String uid, String pcBridgeId);
+  Future<void> requestPcBridgeHealthCheck({
+    required String uid,
+    required String pcBridgeId,
+  });
   Future<SessionSummary> createSession({
     required String uid,
     required String pcBridgeId,
@@ -455,9 +469,45 @@ class FirestoreSessionRepository implements SessionRepository {
             lastQueueCheckedAt: timestampToDateTime(
               data?['lastQueueCheckedAt'],
             ),
+            lastHealthCheckRequestedAt: timestampToDateTime(
+              data?['lastHealthCheckRequestedAt'],
+            ),
+            lastHealthCheckRespondedAt: timestampToDateTime(
+              data?['lastHealthCheckRespondedAt'],
+            ),
+            lastHealthCheckStatus: data?['lastHealthCheckStatus'] as String?,
             status: data?['status'] as String?,
           );
         });
+  }
+
+  @override
+  Future<void> requestPcBridgeHealthCheck({
+    required String uid,
+    required String pcBridgeId,
+  }) async {
+    final bridgeRef = firestore
+        .collection('users')
+        .doc(uid)
+        .collection('pcBridges')
+        .doc(pcBridgeId);
+    final healthCheckRef = bridgeRef.collection('healthChecks').doc();
+    final batch = firestore.batch();
+
+    batch.set(healthCheckRef, {
+      'status': 'requested',
+      'targetPcBridgeId': pcBridgeId,
+      'createdByDeviceId': androidDeviceId,
+      'requestedAt': FieldValue.serverTimestamp(),
+    });
+
+    batch.set(bridgeRef, {
+      'pcBridgeId': pcBridgeId,
+      'lastHealthCheckRequestedAt': FieldValue.serverTimestamp(),
+      'lastHealthCheckStatus': 'requested',
+    }, SetOptions(merge: true));
+
+    await batch.commit();
   }
 
   @override
@@ -751,7 +801,7 @@ class _SessionListViewState extends State<SessionListView> {
   }
 }
 
-class _ConnectionSummary extends StatelessWidget {
+class _ConnectionSummary extends StatefulWidget {
   const _ConnectionSummary({
     required this.bootstrap,
     required this.sessionRepository,
@@ -761,11 +811,41 @@ class _ConnectionSummary extends StatelessWidget {
   final SessionRepository sessionRepository;
 
   @override
+  State<_ConnectionSummary> createState() => _ConnectionSummaryState();
+}
+
+class _ConnectionSummaryState extends State<_ConnectionSummary> {
+  bool isCheckingBridge = false;
+  String? checkError;
+
+  Future<void> requestHealthCheck() async {
+    setState(() {
+      isCheckingBridge = true;
+      checkError = null;
+    });
+
+    try {
+      await widget.sessionRepository.requestPcBridgeHealthCheck(
+        uid: widget.bootstrap.uid,
+        pcBridgeId: widget.bootstrap.pcBridgeId,
+      );
+    } catch (error) {
+      checkError = error.toString();
+    } finally {
+      if (mounted) {
+        setState(() {
+          isCheckingBridge = false;
+        });
+      }
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return StreamBuilder<PcBridgeStatus>(
-      stream: sessionRepository.watchPcBridgeStatus(
-        bootstrap.uid,
-        bootstrap.pcBridgeId,
+      stream: widget.sessionRepository.watchPcBridgeStatus(
+        widget.bootstrap.uid,
+        widget.bootstrap.pcBridgeId,
       ),
       builder: (context, snapshot) {
         final bridge = snapshot.data ?? const PcBridgeStatus();
@@ -786,7 +866,7 @@ class _ConnectionSummary extends StatelessWidget {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'PC bridge: ${bootstrap.pcBridgeId}${bridge.status == null ? '' : ' (${bridge.status})'}',
+                  'PC bridge: ${widget.bootstrap.pcBridgeId}${bridge.status == null ? '' : ' (${bridge.status})'}',
                 ),
                 const SizedBox(height: 4),
                 Text('Last heartbeat: ${formatDateTime(bridge.lastSeenAt)}'),
@@ -796,10 +876,42 @@ class _ConnectionSummary extends StatelessWidget {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  'Notifications: ${bootstrap.notificationState.permissionStatus}',
+                  'Last manual check: ${formatDateTime(bridge.lastHealthCheckRequestedAt)}',
                 ),
                 const SizedBox(height: 4),
-                SelectableText('UID: ${bootstrap.uid}'),
+                Text(
+                  'Last response: ${formatDateTime(bridge.lastHealthCheckRespondedAt)}${bridge.lastHealthCheckStatus == null ? '' : ' (${bridge.lastHealthCheckStatus})'}',
+                ),
+                if (checkError != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    checkError!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 8),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: FilledButton.icon(
+                    onPressed: isCheckingBridge ? null : requestHealthCheck,
+                    icon: isCheckingBridge
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.sensors),
+                    label: Text(isCheckingBridge ? 'Checking' : 'Check PC now'),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Notifications: ${widget.bootstrap.notificationState.permissionStatus}',
+                ),
+                const SizedBox(height: 4),
+                SelectableText('UID: ${widget.bootstrap.uid}'),
               ],
             ),
           ),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -44,8 +44,39 @@ void main() {
 
     expect(find.text('Connected as anonymous user'), findsOneWidget);
     expect(find.text('PC bridge: home-main-pc (active)'), findsOneWidget);
+    expect(find.text('Check PC now'), findsOneWidget);
     expect(find.text('UID: test-uid'), findsOneWidget);
     expect(find.text('No sessions yet'), findsOneWidget);
+  });
+
+  testWidgets('requests a PC bridge health check from the status panel', (
+    tester,
+  ) async {
+    final repository = FakeSessionRepository();
+
+    await tester.pumpWidget(
+      RemoteCodexApp(
+        bootstrap: Future<AppBootstrap>.value(
+          const AppBootstrap(
+            uid: 'test-uid',
+            pcBridgeId: defaultPcBridgeId,
+            notificationState: NotificationState(
+              permissionStatus: 'authorized',
+              hasToken: true,
+            ),
+          ),
+        ),
+        sessionRepository: repository,
+      ),
+    );
+    await tester.pump();
+    repository.emit(const <SessionSummary>[]);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Check PC now'));
+    await tester.pump();
+
+    expect(repository.healthCheckCount, 1);
   });
 
   testWidgets('creates a session from the floating action button', (
@@ -129,6 +160,7 @@ class FakeSessionRepository implements SessionRepository {
   final Map<String, StreamController<List<CommandSummary>>> commandControllers =
       {};
   int createdSessionCount = 0;
+  int healthCheckCount = 0;
   String? createdCommandText;
 
   void emit(List<SessionSummary> sessions) {
@@ -154,9 +186,20 @@ class FakeSessionRepository implements SessionRepository {
         PcBridgeStatus(
           lastSeenAt: DateTime(2026, 4, 26, 12),
           lastQueueCheckedAt: DateTime(2026, 4, 26, 12, 1),
+          lastHealthCheckRequestedAt: DateTime(2026, 4, 26, 12, 2),
+          lastHealthCheckRespondedAt: DateTime(2026, 4, 26, 12, 2, 5),
+          lastHealthCheckStatus: 'responded',
           status: 'active',
         ),
       );
+
+  @override
+  Future<void> requestPcBridgeHealthCheck({
+    required String uid,
+    required String pcBridgeId,
+  }) async {
+    healthCheckCount++;
+  }
 
   void emitCommands(String sessionId, List<CommandSummary> commands) {
     commandControllers

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -21,7 +21,31 @@ service cloud.firestore {
 
       match /pcBridges/{pcBridgeId} {
         allow read: if ownsUser(userId);
-        allow create, update, delete: if false;
+        allow create: if ownsUser(userId)
+          && request.resource.data.keys().hasOnly([
+            "pcBridgeId",
+            "lastHealthCheckRequestedAt",
+            "lastHealthCheckStatus"
+          ])
+          && request.resource.data.pcBridgeId == pcBridgeId
+          && request.resource.data.lastHealthCheckStatus == "requested";
+        allow update: if ownsUser(userId)
+          && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+            "pcBridgeId",
+            "lastHealthCheckRequestedAt",
+            "lastHealthCheckStatus"
+          ])
+          && request.resource.data.pcBridgeId == pcBridgeId
+          && request.resource.data.lastHealthCheckStatus == "requested";
+        allow delete: if false;
+
+        match /healthChecks/{healthCheckId} {
+          allow read: if ownsUser(userId);
+          allow create: if ownsUser(userId)
+            && request.resource.data.status == "requested"
+            && request.resource.data.targetPcBridgeId == pcBridgeId;
+          allow update, delete: if false;
+        }
       }
 
       match /sessions/{sessionId} {

--- a/pc-bridge/README.md
+++ b/pc-bridge/README.md
@@ -240,6 +240,12 @@ Androidアプリを再インストールした場合など、Firebase Anonymous 
 
 これにより、スマホ側のUIDが変わっても、アプリが起動して `users/{uid}.defaultPcBridgeId` を保存した後は、watcherの次回 heartbeat / queue check で新しいUID側にも `lastSeenAt` / `lastQueueCheckedAt` が更新される。`ownerUserId` は明示的に追跡したいユーザーを追加するための任意設定として残す。
 
+### スマホからの任意稼働確認
+
+Androidアプリの `Check PC now` は `users/{uid}/pcBridges/{pcBridgeId}/healthChecks/{healthCheckId}` に `requested` 状態の確認要求を作成する。PCブリッジwatcherは通常の5秒polling中に未応答health checkを検出し、稼働中であれば `responded` と `respondedAt` を書き戻す。
+
+アプリ側では `pcBridges/{pcBridgeId}` の `lastHealthCheckRequestedAt` / `lastHealthCheckRespondedAt` / `lastHealthCheckStatus` を表示する。watcherが停止している場合は応答時刻が更新されないため、直近heartbeatと合わせてPC側常駐プロセスの停止を判断できる。
+
 実Codex実行は作業内容を伴うため、Issueの受入条件が明確な時だけ `cli` modeで検証する。
 
 ### #29 実Codex CLI受け入れ検証

--- a/pc-bridge/src/lib/firestoreRelayRepository.ts
+++ b/pc-bridge/src/lib/firestoreRelayRepository.ts
@@ -184,6 +184,69 @@ export class FirestoreRelayRepository implements CommandRepository {
     }, { merge: true })));
   }
 
+  async respondPendingHealthChecks(pcBridgeId: string, now: Date): Promise<number> {
+    const firestore = await this.getFirestore();
+    const userIds = await this.resolveBridgeUserIds(firestore, pcBridgeId);
+
+    const nowTimestamp = Timestamp.fromDate(now);
+    let respondedCount = 0;
+
+    for (const userId of userIds) {
+      const healthChecks = await firestore
+        .collection(`users/${userId}/pcBridges/${pcBridgeId}/healthChecks`)
+        .where("status", "==", "requested")
+        .limit(20)
+        .get();
+
+      for (const healthCheck of healthChecks.docs) {
+        await firestore.runTransaction(async (transaction) => {
+          const current = await transaction.get(healthCheck.ref);
+
+          if (!current.exists || current.data()?.status !== "requested") {
+            return;
+          }
+
+          if (current.data()?.targetPcBridgeId !== pcBridgeId) {
+            return;
+          }
+
+          const bridgeRef = healthCheck.ref.parent.parent;
+          if (!bridgeRef) {
+            return;
+          }
+
+          transaction.update(healthCheck.ref, {
+            status: "responded",
+            respondedAt: nowTimestamp,
+            respondingPcBridgeId: pcBridgeId,
+            message: "PC bridge watcher responded.",
+          });
+
+          const requestedAt = current.data()?.requestedAt;
+          const bridgeUpdate: Record<string, unknown> = {
+            pcBridgeId,
+            displayName: this.config.displayName,
+            workspaceName: this.config.workspaceName,
+            status: "active",
+            version: "0.1.0",
+            lastHealthCheckRespondedAt: nowTimestamp,
+            lastHealthCheckStatus: "responded",
+          };
+
+          if (requestedAt) {
+            bridgeUpdate.lastHealthCheckRequestedAt = requestedAt;
+          }
+
+          transaction.set(bridgeRef, bridgeUpdate, { merge: true });
+
+          respondedCount += 1;
+        });
+      }
+    }
+
+    return respondedCount;
+  }
+
   private async getFirestore(): Promise<Firestore> {
     if (this.firestorePromise) {
       return this.firestorePromise;

--- a/pc-bridge/src/lib/localRelayRepository.ts
+++ b/pc-bridge/src/lib/localRelayRepository.ts
@@ -127,6 +127,10 @@ export class LocalRelayRepository implements CommandRepository {
     await this.writeState(state);
   }
 
+  async respondPendingHealthChecks(_pcBridgeId: string, _now: Date): Promise<number> {
+    return 0;
+  }
+
   private async updateClaimedCommand(
     claim: CommandClaim,
     now: Date,

--- a/pc-bridge/src/lib/types.ts
+++ b/pc-bridge/src/lib/types.ts
@@ -63,6 +63,7 @@ export type CommandRepository = {
   markFailed(claim: CommandClaim, errorText: string, now: Date): Promise<void>;
   updateHeartbeat(pcBridgeId: string, now: Date): Promise<void>;
   updateQueueCheck(pcBridgeId: string, now: Date): Promise<void>;
+  respondPendingHealthChecks(pcBridgeId: string, now: Date): Promise<number>;
 };
 
 export type CodexInvocation = {

--- a/pc-bridge/src/watch.ts
+++ b/pc-bridge/src/watch.ts
@@ -39,6 +39,11 @@ async function main(): Promise<void> {
   while (!shuttingDown) {
     try {
       await repository.updateQueueCheck(config.pcBridgeId, new Date());
+      const respondedHealthChecks = await repository.respondPendingHealthChecks(config.pcBridgeId, new Date());
+
+      if (respondedHealthChecks > 0) {
+        console.log(`Responded to ${respondedHealthChecks} health check(s).`);
+      }
 
       let processedCount = 0;
 


### PR DESCRIPTION
## Summary
- Add Android Check PC now action backed by Firestore health check requests
- Let the PC bridge watcher respond to requested health checks during polling
- Show last manual check and last response status in the Android status panel
- Deploy Firestore rules for constrained health check writes
- Document the health check flow

Closes #71.

## Validation
- npm.cmd run check
- npm.cmd run validate:local
- flutter analyze
- flutter test
- flutter build apk --debug
- flutter install -d 192.168.0.3:38579 --debug
- firebase deploy --only firestore:rules --project remotecodex-c52ae
- Firestore smoke: requested health check changed to responded by watcher