### PR TITLE
CLIオプションの表示場所とヘルプを整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Android app and PC-side bridge for sending instructions from a phone to Codex ru
 Build a Flutter Android app that can:
 
 - Start a new remote Codex session.
-- Choose Codex CLI model and main execution options when starting a session.
+- Choose per-session Codex CLI options when starting a session and keep stable execution options in app defaults.
 - Select an existing remote Codex session.
 - Send text instructions to a selected session.
 - Show only the final result in the app.
@@ -29,7 +29,7 @@ This avoids opening inbound ports on the home network and allows cellular access
 
 ## Current Setup Status
 
-- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, stores CLI option defaults, lets new sessions choose Codex CLI model/options, shows session options on long press, queues text commands for the PC bridge, shows running progress logs, can request an on-demand PC bridge health check, routes notification taps to the target session, and uses the custom RemoteCodex launcher icon.
+- `app/`: Flutter Android project generated for package `com.sunmax.remotecodex`. Startup initializes Firebase, signs in anonymously, stores FCM tokens, shows sessions, stores CLI option defaults, lets new sessions choose per-session Codex CLI model/profile values, exposes CLI option help, shows session options on long press, queues text commands for the PC bridge, shows running progress logs, can request an on-demand PC bridge health check, routes notification taps to the target session, and uses the custom RemoteCodex launcher icon.
 - `pc-bridge/`: Node.js/TypeScript bridge with local relay and Firestore relay support. Current local config can run `codexMode: cli` with a fixed Codex model, return 1-minute progress logs while Codex CLI is running, respond to on-demand health checks, follow Android anonymous UID changes for bridge status, and `start:watch` can keep polling queued commands. Windows batch files under `pc-bridge/scripts/` can run the watcher in the background or register it with Task Scheduler.
 - `firebase/`: Firebase relay scaffold linked to project `remotecodex-c52ae`, with Firestore rules, command query index, and a Cloud Function that sends FCM completion notifications.
 - `docs/development-setup.md`: Local toolchain status, wireless debugging workflow, and Firebase/Flutter setup handoff.

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -12,6 +12,7 @@ const defaultPcBridgeId = 'home-main-pc';
 const defaultCodexModel = 'gpt-5.4';
 const defaultCodexSandbox = 'workspace-write';
 const codexModelOptions = [
+  'gpt-5.5',
   'gpt-5.4',
   'gpt-5.4-mini',
   'gpt-5.3-codex',
@@ -22,6 +23,93 @@ const codexSandboxOptions = [
   'read-only',
   'workspace-write',
   'danger-full-access',
+];
+const cliOptionHelpItems = [
+  CliOptionHelp(
+    name: 'Model',
+    location: 'New Session / CLI defaults',
+    description: 'セッションで使用するCodexモデルを選びます。',
+  ),
+  CliOptionHelp(
+    name: 'Profile',
+    location: 'New Session / CLI defaults',
+    description: 'PC側のCodex設定にある名前付きprofileを使用します。',
+  ),
+  CliOptionHelp(
+    name: 'Sandbox',
+    location: 'CLI defaults',
+    description: 'CodexがPC上のファイルへどこまでアクセスできるかを制御します。',
+  ),
+  CliOptionHelp(
+    name: 'Bypass sandbox',
+    location: 'CLI defaults',
+    description: 'PCブリッジでsandbox制限を迂回してCodexを実行します。',
+  ),
+  CliOptionHelp(
+    name: '--config key=value',
+    location: 'Advanced / future',
+    description: '1回の実行だけCodex設定値を上書きします。',
+  ),
+  CliOptionHelp(
+    name: '--enable / --disable',
+    location: 'Advanced / future',
+    description: 'Codexの機能フラグを有効化または無効化します。',
+  ),
+  CliOptionHelp(
+    name: '--image',
+    location: 'Advanced / future',
+    description: '画像を使う依頼で、入力画像のパスを追加します。',
+  ),
+  CliOptionHelp(
+    name: '--oss',
+    location: 'Advanced / future',
+    description: '設定済みの場合にローカルOSS providerモードを使います。',
+  ),
+  CliOptionHelp(
+    name: '--local-provider',
+    location: 'Advanced / future',
+    description: 'OSSモードで使うローカルproviderを選びます。',
+  ),
+  CliOptionHelp(
+    name: '--full-auto',
+    location: 'Advanced / future',
+    description: '確認を減らして自動実行寄りで進めます。',
+  ),
+  CliOptionHelp(
+    name: '--add-dir',
+    location: 'Advanced / future',
+    description: 'Codexセッションに追加の作業ディレクトリを渡します。',
+  ),
+  CliOptionHelp(
+    name: '--skip-git-repo-check',
+    location: 'Advanced / future',
+    description: '対象がGitリポジトリでなくても実行できるようにします。',
+  ),
+  CliOptionHelp(
+    name: '--ephemeral',
+    location: 'Advanced / future',
+    description: '後から再開するためのセッション状態を保存せずに開始します。',
+  ),
+  CliOptionHelp(
+    name: '--ignore-user-config',
+    location: 'Advanced / future',
+    description: 'PCユーザー単位のCodex設定を無視します。',
+  ),
+  CliOptionHelp(
+    name: '--ignore-rules',
+    location: 'Advanced / future',
+    description: 'リポジトリまたはユーザーの指示ファイルを無視します。',
+  ),
+  CliOptionHelp(
+    name: '--output-schema',
+    location: 'Advanced / future',
+    description: 'JSON schemaに沿った出力を要求します。',
+  ),
+  CliOptionHelp(
+    name: '--json',
+    location: 'PC bridge internal',
+    description: 'PCブリッジが扱いやすい機械可読イベントを出力します。',
+  ),
 ];
 const androidDeviceId = 'android-app';
 const notificationChannelId = 'remote_codex_completion';
@@ -820,6 +908,7 @@ class _SessionListViewState extends State<SessionListView> {
       title: 'New session',
       initialOptions: defaults,
       primaryLabel: 'Create',
+      showExecutionDefaults: false,
     );
     if (options == null) {
       return;
@@ -948,6 +1037,7 @@ Future<SessionCreateOptions?> showSessionOptionsDialog(
   required String title,
   required SessionCreateOptions initialOptions,
   required String primaryLabel,
+  required bool showExecutionDefaults,
 }) {
   final profileController = TextEditingController(
     text: initialOptions.codexProfile ?? '',
@@ -985,22 +1075,6 @@ Future<SessionCreateOptions?> showSessionOptionsDialog(
                     },
                   ),
                   const SizedBox(height: 12),
-                  DropdownButtonFormField<String>(
-                    initialValue: sandbox,
-                    decoration: const InputDecoration(labelText: 'Sandbox'),
-                    items: [
-                      for (final option in codexSandboxOptions)
-                        DropdownMenuItem(value: option, child: Text(option)),
-                    ],
-                    onChanged: bypassSandbox
-                        ? null
-                        : (value) {
-                            if (value != null) {
-                              setDialogState(() => sandbox = value);
-                            }
-                          },
-                  ),
-                  const SizedBox(height: 12),
                   TextField(
                     controller: profileController,
                     decoration: const InputDecoration(
@@ -1008,18 +1082,50 @@ Future<SessionCreateOptions?> showSessionOptionsDialog(
                       hintText: 'Optional config profile',
                     ),
                   ),
-                  SwitchListTile(
-                    contentPadding: EdgeInsets.zero,
-                    title: const Text('Bypass sandbox'),
-                    value: bypassSandbox,
-                    onChanged: (value) {
-                      setDialogState(() => bypassSandbox = value);
-                    },
-                  ),
+                  if (showExecutionDefaults) ...[
+                    const SizedBox(height: 12),
+                    DropdownButtonFormField<String>(
+                      initialValue: sandbox,
+                      decoration: const InputDecoration(labelText: 'Sandbox'),
+                      items: [
+                        for (final option in codexSandboxOptions)
+                          DropdownMenuItem(value: option, child: Text(option)),
+                      ],
+                      onChanged: bypassSandbox
+                          ? null
+                          : (value) {
+                              if (value != null) {
+                                setDialogState(() => sandbox = value);
+                              }
+                            },
+                    ),
+                    SwitchListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Bypass sandbox'),
+                      subtitle: const Text('Overrides the sandbox selection'),
+                      value: bypassSandbox,
+                      onChanged: (value) {
+                        setDialogState(() => bypassSandbox = value);
+                      },
+                    ),
+                  ] else ...[
+                    const SizedBox(height: 8),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        'Sandbox and bypass use CLI defaults.',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                  ],
                 ],
               ),
             ),
             actions: [
+              TextButton(
+                onPressed: () => showCliOptionHelpDialog(context),
+                child: const Text('Help'),
+              ),
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
                 child: const Text('Cancel'),
@@ -1046,6 +1152,58 @@ Future<SessionCreateOptions?> showSessionOptionsDialog(
   ).whenComplete(() {
     profileController.dispose();
   });
+}
+
+Future<void> showCliOptionHelpDialog(BuildContext context) {
+  return showDialog<void>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('CLI option help'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemCount: cliOptionHelpItems.length,
+          separatorBuilder: (context, index) => const Divider(height: 18),
+          itemBuilder: (context, index) {
+            final option = cliOptionHelpItems[index];
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  option.name,
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(height: 2),
+                Text('表示場所: ${option.location}'),
+                const SizedBox(height: 2),
+                Text(option.description),
+              ],
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    ),
+  );
+}
+
+class CliOptionHelp {
+  const CliOptionHelp({
+    required this.name,
+    required this.location,
+    required this.description,
+  });
+
+  final String name;
+  final String location;
+  final String description;
 }
 
 Future<void> showSessionOptionsSummaryDialog(
@@ -1147,6 +1305,7 @@ class _ConnectionSummaryState extends State<_ConnectionSummary> {
       title: 'CLI defaults',
       initialOptions: defaults,
       primaryLabel: 'Save',
+      showExecutionDefaults: true,
     );
 
     if (updated == null) {
@@ -1246,6 +1405,11 @@ class _ConnectionSummaryState extends State<_ConnectionSummary> {
                         label: Text(
                           isOpeningDefaults ? 'Loading' : 'CLI defaults',
                         ),
+                      ),
+                      OutlinedButton.icon(
+                        onPressed: () => showCliOptionHelpDialog(context),
+                        icon: const Icon(Icons.help_outline),
+                        label: const Text('CLI option help'),
                       ),
                     ],
                   ),

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -46,8 +46,21 @@ void main() {
     expect(find.text('PC bridge: home-main-pc (active)'), findsOneWidget);
     expect(find.text('Check PC now'), findsOneWidget);
     expect(find.text('CLI defaults'), findsOneWidget);
+    expect(find.text('CLI option help'), findsOneWidget);
     expect(find.text('UID: test-uid'), findsOneWidget);
     expect(find.text('No sessions yet'), findsOneWidget);
+  });
+
+  test('includes gpt-5.5 in model options', () {
+    expect(codexModelOptions, contains('gpt-5.5'));
+  });
+
+  test('documents advanced CLI option meanings', () {
+    final optionNames = cliOptionHelpItems.map((option) => option.name);
+
+    expect(optionNames, contains('--config key=value'));
+    expect(optionNames, contains('--add-dir'));
+    expect(optionNames, contains('--json'));
   });
 
   testWidgets('requests a PC bridge health check from the status panel', (
@@ -104,10 +117,42 @@ void main() {
 
     await tester.tap(find.text('CLI defaults'));
     await tester.pumpAndSettle();
+    expect(find.text('Sandbox'), findsOneWidget);
+    expect(find.text('Bypass sandbox'), findsOneWidget);
     await tester.tap(find.text('Save'));
     await tester.pump();
 
     expect(repository.savedDefaultsCount, 1);
+  });
+
+  testWidgets('shows CLI option help from the status panel', (tester) async {
+    final repository = FakeSessionRepository();
+
+    await tester.pumpWidget(
+      RemoteCodexApp(
+        bootstrap: Future<AppBootstrap>.value(
+          const AppBootstrap(
+            uid: 'test-uid',
+            pcBridgeId: defaultPcBridgeId,
+            notificationState: NotificationState(
+              permissionStatus: 'authorized',
+              hasToken: true,
+            ),
+          ),
+        ),
+        sessionRepository: repository,
+      ),
+    );
+    await tester.pump();
+    repository.emit(const <SessionSummary>[]);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('CLI option help'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('CLI option help'), findsWidgets);
+    expect(find.text('Model'), findsOneWidget);
+    expect(find.text('Profile'), findsOneWidget);
   });
 
   testWidgets('shows session CLI options on long press', (tester) async {
@@ -177,6 +222,8 @@ void main() {
     await tester.tap(find.text('New session'));
     await tester.pump();
     expect(find.text(defaultCodexModel), findsOneWidget);
+    expect(find.text('Sandbox'), findsNothing);
+    expect(find.text('Sandbox and bypass use CLI defaults.'), findsOneWidget);
     await tester.tap(find.text('Create'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));


### PR DESCRIPTION
## Summary
- New Session はセッションごとに変わりやすい Model/Profile の入力に絞り、Sandbox/Bypass は CLI defaults に集約
- gpt-5.5 をモデル候補に追加
- CLI option help を追加し、主要CLIオプションの意味と表示場所をスマホアプリから参照可能にした
- README と widget test を更新

## Validation
- `D:\tools\flutter\bin\flutter.bat analyze`
- `D:\tools\flutter\bin\flutter.bat test`
- `D:\tools\flutter\bin\flutter.bat build apk --debug`
- `D:\tools\flutter\bin\flutter.bat install -d 192.168.0.3:38579 --debug`

Closes #77