### PR TITLE
docs: Androidリリースインストール証跡を追加

### DIFF
--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -1,41 +1,42 @@
-# Release Plan
+# リリース計画
 
-## Release Target
+## リリース対象
 
-Installable Android app on Xperia 1 III.
+Xperia 1 IIIにインストールできるAndroidアプリをMVPのRelease対象とする。
 
-The first release may be a debug APK or internal signed APK. Google Play publication is not required for MVP.
+最初のReleaseはdebug署名または内部配布用署名のAPKでよい。Google Play公開はMVP範囲外とする。
 
-## Release Readiness Checklist
+## Release準備チェックリスト
 
-- Android app can authenticate.
-- Android app can create a session.
-- Android app can select a session.
-- Android app can send a text command.
-- PC bridge receives and processes the command.
-- Final result is visible in the app.
-- Running progress summary is visible when the PC bridge reports progress.
-- Completion push notification is delivered.
-- App follows the device language for Japanese, English, Chinese, and Korean, with English fallback for unsupported languages.
-- App works over cellular network.
-- App layout is usable on Xperia 1 III portrait display.
-- Secrets are excluded from Git.
-- Release notes describe setup requirements for the PC bridge.
+- Androidアプリで認証できる。
+- Androidアプリでセッションを作成できる。
+- Androidアプリで既存セッションを選択できる。
+- Androidアプリからテキスト指示を送信できる。
+- PCブリッジが指示を受信し、Codex CLIで処理できる。
+- 最終結果をアプリで確認できる。
+- PCブリッジが進捗を返した場合、running中の進捗概要をアプリで確認できる。
+- 完了プッシュ通知が届く。
+- 日本語、英語、中国語、韓国語で端末言語追従を確認できる。
+- 未対応言語では英語にフォールバックする。
+- 携帯電話回線でも利用できる。
+- Xperia 1 IIIの縦画面で主要操作ができる。
+- 秘密情報がGitに含まれていない。
+- Release notesにPCブリッジのセットアップ要件と既知制限を記載する。
 
-## Installation Definition
+## インストール完了定義
 
-Release is complete when:
+Releaseは次を満たした時点で完了とする。
 
-1. APK is built.
-2. APK is installed on the Xperia 1 III.
-3. The installed app completes one end-to-end command cycle with the home PC.
+1. APKがビルドされている。
+2. APKがXperia 1 IIIにインストールされている。
+3. インストール済みアプリで、自宅PCとの1回以上のend-to-endコマンドサイクルが完了している。
 
-## Post-MVP Release Candidates
+## Post-MVP候補
 
-- Start VS Code automatically from the PC bridge.
-- Local LAN discovery mode.
-- Command cancellation.
-- Session search.
-- Encrypted session payloads.
-- Multiple PC bridge registration.
-- ARB-based translation workflow or professional translation management.
+- PCブリッジからVS Codeを自動起動する。
+- LAN内探索モードを追加する。
+- コマンドキャンセルを追加する。
+- セッション検索を追加する。
+- セッションpayloadを暗号化する。
+- 複数PCブリッジ登録に対応する。
+- ARBベースの翻訳管理または専門翻訳ワークフローを導入する。

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -1,0 +1,98 @@
+# Release 1.0.0 証跡
+
+実施日: 2026-04-27
+
+対象Issue: #8
+
+## リリース対象
+
+| 項目 | 値 |
+| --- | --- |
+| アプリversion | `1.0.0` |
+| build number / versionCode | `1` |
+| package name | `com.sunmax.remotecodex` |
+| 対象端末 | Xperia 1 III / SO-51B |
+| release commit | `2f9c5781031b93b75420cd9728948027cda4657b` |
+| APK | `app/build/app/outputs/flutter-apk/app-release.apk` |
+| APK size | `52,796,321 bytes` |
+| APK SHA-256 | `F45A6C2CA7E06E6029F9609BECFD9AFB889494F6EC92EFD0F1C144B91F5A4E9E` |
+
+## 実施内容
+
+### Release blocker確認
+
+確認時点のopen Issueは #8 のみ。
+
+Phase 7の次のIssueは完了済み。
+
+- #95 Phase 7 QAベースライン
+- #96 Phase 7 手動E2E・通知・携帯回線確認
+- #97 npm auditのlow/moderate脆弱性警告をRelease前に評価する
+
+### 自動検証
+
+| 項目 | コマンド | 結果 |
+| --- | --- | --- |
+| Flutter analyze | `flutter analyze` (`app/`) | 成功 |
+| Flutter test | `flutter test` (`app/`) | 成功、13 tests passed |
+| Release APK build | `flutter build apk --release` (`app/`) | 成功 |
+
+### 実機インストール
+
+最初に `192.168.0.3:37329` がofflineになっていたため、ADB serverを再起動した。
+
+再接続後、次のdevice idで端末を検出した。
+
+```text
+192.168.0.3:32811 device product:SO-51B model:SO_51B device:SO-51B
+```
+
+次のコマンドでrelease APKをインストールした。
+
+```powershell
+adb -s 192.168.0.3:32811 install -r build\app\outputs\flutter-apk\app-release.apk
+```
+
+結果:
+
+```text
+Performing Streamed Install
+Success
+```
+
+インストール後、ランチャー起動を確認した。
+
+```powershell
+adb -s 192.168.0.3:32811 shell monkey -p com.sunmax.remotecodex -c android.intent.category.LAUNCHER 1
+```
+
+端末上のインストール情報:
+
+```text
+versionCode=1 minSdk=24 targetSdk=36
+versionName=1.0.0
+lastUpdateTime=2026-04-27 01:57:00
+firstInstallTime=2026-04-27 01:39:19
+```
+
+## Release smoke test
+
+release APKのインストールと起動までは完了。
+
+次の項目はスマホ操作を伴うため、ユーザー確認待ち。
+
+- release APKとしてインストール済みアプリからNew sessionを作成できる。
+- スマホから指示を送信し、queued -> running -> completedへ進む。
+- PCブリッジがCodex CLIで処理する。
+- アプリに進捗概要と最終結果が表示される。
+- 完了通知が届く。
+
+これらが確認できたら #8 に結果をコメントし、GitHub Release公開とIssueクローズへ進む。
+
+## 既知制限
+
+- Release buildは現時点でdebug signing configを使っている。Google Play公開用の正式署名ではない。
+- Google Play公開はMVP範囲外。
+- `npm audit` のlow/moderate警告は #97 で既知制限として評価済み。high/criticalは検出されていない。
+- ワイヤレスデバッグのdevice idとポートは変わる。インストール前に `flutter devices` または `adb devices -l` で確認する。
+

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -77,17 +77,20 @@ firstInstallTime=2026-04-27 01:39:19
 
 ## Release smoke test
 
-release APKのインストールと起動までは完了。
+2026-04-27に、ユーザー操作でrelease APKとしてインストール済みのアプリを確認した。
 
-次の項目はスマホ操作を伴うため、ユーザー確認待ち。
+確認結果:
 
-- release APKとしてインストール済みアプリからNew sessionを作成できる。
-- スマホから指示を送信し、queued -> running -> completedへ進む。
-- PCブリッジがCodex CLIで処理する。
-- アプリに進捗概要と最終結果が表示される。
-- 完了通知が届く。
+- APKがXperia 1 IIIにインストールされている。
+- インストール済みアプリで、自宅PCとの1回以上の完全なコマンドサイクルが完了した。
+- スマホから送信後、18秒で回答を取得できた。
+- 完了プッシュ通知が届いた。
 
-これらが確認できたら #8 に結果をコメントし、GitHub Release公開とIssueクローズへ進む。
+確認コメント:
+
+- #8: https://github.com/Sunmax0731/codex-remote-android/issues/8#issuecomment-4322535545
+
+これにより、#8 のRelease完了条件を満たした。
 
 ## 既知制限
 
@@ -95,4 +98,3 @@ release APKのインストールと起動までは完了。
 - Google Play公開はMVP範囲外。
 - `npm audit` のlow/moderate警告は #97 で既知制限として評価済み。high/criticalは検出されていない。
 - ワイヤレスデバッグのdevice idとポートは変わる。インストール前に `flutter devices` または `adb devices -l` で確認する。
-

--- a/process/08-release/Agents.md
+++ b/process/08-release/Agents.md
@@ -2,22 +2,23 @@
 
 ## Release Agent
 
-- Build the Android APK.
-- Install the APK on the target phone.
-- Record version, build number, and commit SHA.
-- Use `flutter devices` to confirm the current wireless-debugging device ID before installing debug builds.
+- Android APKをビルドする。
+- 対象スマホへAPKをインストールする。
+- version、build number、commit SHAを記録する。
+- debug buildまたはワイヤレスデバッグを使う場合、インストール直前に `flutter devices` または `adb devices -l` で現在のdevice idを確認する。
 
 ## Documentation Agent
 
-- Write release notes and setup instructions.
-- Document PC bridge prerequisites.
+- Release notesを作成する。
+- セットアップ手順を更新する。
+- PCブリッジの前提条件、既知制限、秘密情報の扱いを記録する。
 
 ## Verification Agent
 
-- Verify the installed app completes the end-to-end workflow.
-- Confirm notification delivery after installation.
-- Confirm progress display and supported locale behavior for releases that change Android UI text.
+- インストール済みアプリでend-to-end workflowが完了することを確認する。
+- インストール後に完了通知が届くことを確認する。
+- Android UIテキストを変更したReleaseでは、進捗表示と対応言語の表示を確認する。
 
 ## Handoff
 
-This phase is complete when the app is installed on the Xperia 1 III and the release issue records successful end-to-end verification.
+この工程は、Xperia 1 IIIにアプリがインストールされ、Release Issueにend-to-end検証結果が記録された時点で完了とする。

--- a/process/08-release/Skill.md
+++ b/process/08-release/Skill.md
@@ -1,32 +1,42 @@
 # Skill: Release
 
-## Steps
+## 目的
 
-1. Confirm all release-blocking issues are closed.
-2. Update version and build number.
-3. Build APK.
-4. Confirm the wireless-debugging device ID with `flutter devices`.
-5. Install APK on Xperia 1 III with `flutter install -d <device-id> --debug` for debug releases, or `adb install` for a signed APK artifact.
-6. Run the release smoke test:
-   - create or select session
-   - send command
-   - PC bridge processes command
-   - running progress is visible when the bridge reports it
-   - final result appears
-   - push notification arrives
-7. Spot-check supported locale behavior when UI text changed in the release:
-   - Japanese
-   - English
-   - Chinese
-   - Korean
-   - English fallback for unsupported locales where practical
-8. Tag the release commit.
-9. Publish GitHub Release with APK if appropriate.
+AndroidアプリをRelease APKとしてビルドし、対象端末へインストールできる状態まで進める。
 
-## Validation
+## 手順
 
-- APK is installed on the phone.
-- End-to-end command cycle passes.
-- Notification arrives after completion.
-- Supported locale behavior is either verified or explicitly deferred with a reason.
-- Release notes include setup and known limitations.
+1. Release blockerのIssueがすべてクローズされていることを確認する。
+2. versionとbuild numberを確認し、必要があれば更新する。
+3. APKをビルドする。
+4. `flutter devices` または `adb devices -l` で現在のワイヤレスデバッグdevice idを確認する。
+5. debug releaseの場合は `flutter install -d <device-id> --debug`、release APKの場合は `adb install` でXperia 1 IIIへインストールする。
+6. Release smoke testを実施する。
+   - セッションを作成または選択する。
+   - 指示を送信する。
+   - PCブリッジが指示を処理する。
+   - bridgeが進捗を返す場合、running中の進捗概要が表示される。
+   - 最終結果が表示される。
+   - 完了通知が届く。
+7. UIテキストを変更したReleaseでは、対応言語の表示をスポット確認する。
+   - 日本語
+   - 英語
+   - 中国語
+   - 韓国語
+   - 可能であれば未対応言語の英語フォールバック
+8. Release commitにtagを付ける。
+9. 必要に応じてAPK付きのGitHub Releaseを公開する。
+
+## 検証
+
+- APKがスマホにインストールされている。
+- end-to-endコマンドサイクルが完了する。
+- 完了通知が届く。
+- 対応言語の表示を確認済み、または理由付きで明示的に延期している。
+- Release notesにセットアップ要件と既知制限が含まれている。
+
+## 注意点
+
+- ワイヤレスデバッグのdevice idとポートは変わるため、インストール直前に必ず確認する。
+- 端末がofflineの場合は、ADB server再起動やスマホ側のワイヤレスデバッグ再接続を試す。
+- 正式なストア公開にはdebug signing configでは不十分。Google Play公開時は専用署名鍵を用意する。


### PR DESCRIPTION
## 概要
- #8 を日本語化したうえで、Release 1.0.0のビルド/実機インストール証跡を追加
- リリース計画とPhase 8のAgents/Skillを日本語化
- release APKのビルド、Xperia 1 IIIへのインストール、起動確認まで記録

## 検証
- `flutter analyze` (`app/`)
- `flutter test` (`app/`)
- `flutter build apk --release` (`app/`)
- `adb -s 192.168.0.3:32811 install -r build\app\outputs\flutter-apk\app-release.apk`
- `adb -s 192.168.0.3:32811 shell monkey -p com.sunmax.remotecodex -c android.intent.category.LAUNCHER 1`
- `git diff --check`

## 残り
- release APKとしてインストール済みアプリでの手動E2E smoke確認
- 完了後にGitHub Release公開と #8 クローズ