### PR TITLE
APK単体配布向けFirebase接続先セットアップを追加する

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ui';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -9,13 +10,17 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 part 'src/core/constants.dart';
 part 'src/l10n/app_strings.dart';
 part 'src/bootstrap/bootstrap.dart';
+part 'src/models/firebase_setup_models.dart';
 part 'src/models/session_models.dart';
+part 'src/services/firebase_config_store.dart';
 part 'src/repositories/session_repository.dart';
 part 'src/app/remote_codex_app.dart';
+part 'src/views/firebase_setup_view.dart';
 part 'src/views/session_list_view.dart';
 part 'src/dialogs/session_options_dialog.dart';
 part 'src/dialogs/text_value_dialogs.dart';

--- a/app/lib/src/app/remote_codex_app.dart
+++ b/app/lib/src/app/remote_codex_app.dart
@@ -3,12 +3,14 @@ part of '../../main.dart';
 class RemoteCodexApp extends StatelessWidget {
   const RemoteCodexApp({
     super.key,
-    required this.bootstrap,
+    this.bootstrap,
     required this.sessionRepository,
+    this.firebaseConfigStore,
   });
 
-  final Future<AppBootstrap> bootstrap;
+  final Future<AppBootstrap>? bootstrap;
   final SessionRepository sessionRepository;
+  final FirebaseConfigStore? firebaseConfigStore;
 
   @override
   Widget build(BuildContext context) {
@@ -34,12 +36,122 @@ class RemoteCodexApp extends StatelessWidget {
         useMaterial3: true,
       ),
       themeMode: ThemeMode.system,
-      home: StartupView(
-        bootstrap: bootstrap,
-        sessionRepository: sessionRepository,
-      ),
+      home: bootstrap == null
+          ? FirebaseSetupGate(
+              firebaseConfigStore:
+                  firebaseConfigStore ??
+                  const SharedPreferencesFirebaseConfigStore(),
+              sessionRepository: sessionRepository,
+            )
+          : StartupView(
+              bootstrap: bootstrap!,
+              sessionRepository: sessionRepository,
+              firebaseConfigStore: firebaseConfigStore,
+            ),
     );
   }
+}
+
+class FirebaseSetupGate extends StatefulWidget {
+  const FirebaseSetupGate({
+    super.key,
+    required this.firebaseConfigStore,
+    required this.sessionRepository,
+  });
+
+  final FirebaseConfigStore firebaseConfigStore;
+  final SessionRepository sessionRepository;
+
+  @override
+  State<FirebaseSetupGate> createState() => _FirebaseSetupGateState();
+}
+
+class _FirebaseSetupGateState extends State<FirebaseSetupGate> {
+  late Future<_SavedFirebaseSetup> _savedSetup;
+  Future<AppBootstrap>? _bootstrap;
+
+  @override
+  void initState() {
+    super.initState();
+    _savedSetup = _loadSavedSetup();
+  }
+
+  Future<_SavedFirebaseSetup> _loadSavedSetup() async {
+    final config = await widget.firebaseConfigStore.load();
+    if (config != null) {
+      return _SavedFirebaseSetup(config: config);
+    }
+    return _SavedFirebaseSetup(
+      useBundledConfig: await widget.firebaseConfigStore
+          .loadBundledConfigEnabled(),
+    );
+  }
+
+  Future<void> startWithConfig(
+    FirebaseClientConfig? config, {
+    bool persistBundledConfig = false,
+  }) async {
+    if (config != null) {
+      await widget.firebaseConfigStore.save(config);
+    } else if (persistBundledConfig) {
+      await widget.firebaseConfigStore.saveBundledConfig();
+    }
+
+    setState(() {
+      _bootstrap = bootstrapRemoteCodex(config: config);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bootstrap = _bootstrap;
+    if (bootstrap != null) {
+      return StartupView(
+        bootstrap: bootstrap,
+        sessionRepository: widget.sessionRepository,
+        firebaseConfigStore: widget.firebaseConfigStore,
+      );
+    }
+
+    return FutureBuilder<_SavedFirebaseSetup>(
+      future: _savedSetup,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('RemoteCodex')),
+            body: const SafeArea(
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          );
+        }
+
+        final savedSetup = snapshot.data;
+        if (savedSetup?.config != null ||
+            savedSetup?.useBundledConfig == true) {
+          scheduleMicrotask(() => startWithConfig(savedSetup?.config));
+          return Scaffold(
+            appBar: AppBar(title: const Text('RemoteCodex')),
+            body: const SafeArea(
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          );
+        }
+
+        return FirebaseSetupView(
+          onConfigured: startWithConfig,
+          onUseBundledConfig: () =>
+              startWithConfig(null, persistBundledConfig: true),
+        );
+      },
+    );
+  }
+}
+
+class _SavedFirebaseSetup {
+  const _SavedFirebaseSetup({this.config, this.useBundledConfig = false});
+
+  final FirebaseClientConfig? config;
+  final bool useBundledConfig;
 }
 
 class StartupView extends StatelessWidget {
@@ -47,10 +159,12 @@ class StartupView extends StatelessWidget {
     super.key,
     required this.bootstrap,
     required this.sessionRepository,
+    this.firebaseConfigStore,
   });
 
   final Future<AppBootstrap> bootstrap;
   final SessionRepository sessionRepository;
+  final FirebaseConfigStore? firebaseConfigStore;
 
   @override
   Widget build(BuildContext context) {
@@ -76,6 +190,7 @@ class StartupView extends StatelessWidget {
           body = SessionListView(
             bootstrap: snapshot.requireData,
             sessionRepository: sessionRepository,
+            firebaseConfigStore: firebaseConfigStore,
           );
         }
 

--- a/app/lib/src/bootstrap/bootstrap.dart
+++ b/app/lib/src/bootstrap/bootstrap.dart
@@ -1,7 +1,9 @@
 part of '../../main.dart';
 
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
+  DartPluginRegistrant.ensureInitialized();
+  final config = await const SharedPreferencesFirebaseConfigStore().load();
+  await initializeFirebase(config: config);
 }
 
 void main() {
@@ -9,14 +11,29 @@ void main() {
   FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
   runApp(
     RemoteCodexApp(
-      bootstrap: bootstrapRemoteCodex(),
+      firebaseConfigStore: const SharedPreferencesFirebaseConfigStore(),
       sessionRepository: FirestoreSessionRepository(),
     ),
   );
 }
 
-Future<AppBootstrap> bootstrapRemoteCodex() async {
-  await Firebase.initializeApp();
+Future<void> initializeFirebase({FirebaseClientConfig? config}) async {
+  if (Firebase.apps.isNotEmpty) {
+    return;
+  }
+
+  if (config == null) {
+    await Firebase.initializeApp();
+    return;
+  }
+
+  await Firebase.initializeApp(options: config.toFirebaseOptions());
+}
+
+Future<AppBootstrap> bootstrapRemoteCodex({
+  FirebaseClientConfig? config,
+}) async {
+  await initializeFirebase(config: config);
   final firestore = FirebaseFirestore.instance;
 
   final credential = await FirebaseAuth.instance.signInAnonymously();
@@ -42,6 +59,7 @@ Future<AppBootstrap> bootstrapRemoteCodex() async {
     uid: uid,
     pcBridgeId: defaultPcBridgeId,
     notificationState: notificationState,
+    firebaseConfig: config,
   );
 }
 
@@ -50,11 +68,13 @@ class AppBootstrap {
     required this.uid,
     required this.pcBridgeId,
     required this.notificationState,
+    this.firebaseConfig,
   });
 
   final String uid;
   final String pcBridgeId;
   final NotificationState notificationState;
+  final FirebaseClientConfig? firebaseConfig;
 }
 
 class NotificationState {

--- a/app/lib/src/models/firebase_setup_models.dart
+++ b/app/lib/src/models/firebase_setup_models.dart
@@ -1,0 +1,118 @@
+part of '../../main.dart';
+
+class FirebaseClientConfig {
+  const FirebaseClientConfig({
+    required this.projectId,
+    required this.apiKey,
+    required this.appId,
+    required this.messagingSenderId,
+    this.authDomain,
+    this.storageBucket,
+  });
+
+  final String projectId;
+  final String apiKey;
+  final String appId;
+  final String messagingSenderId;
+  final String? authDomain;
+  final String? storageBucket;
+
+  FirebaseOptions toFirebaseOptions() {
+    return FirebaseOptions(
+      apiKey: apiKey,
+      appId: appId,
+      messagingSenderId: messagingSenderId,
+      projectId: projectId,
+      authDomain: authDomain,
+      storageBucket: storageBucket,
+    );
+  }
+
+  Map<String, String> toJson() {
+    final data = {
+      'projectId': projectId,
+      'apiKey': apiKey,
+      'appId': appId,
+      'messagingSenderId': messagingSenderId,
+    };
+    final authDomainValue = authDomain;
+    final storageBucketValue = storageBucket;
+    if (authDomainValue != null) {
+      data['authDomain'] = authDomainValue;
+    }
+    if (storageBucketValue != null) {
+      data['storageBucket'] = storageBucketValue;
+    }
+    return data;
+  }
+
+  static FirebaseClientConfig? fromJson(Map<String, dynamic> json) {
+    final projectId = nonEmptyString(json['projectId']);
+    final apiKey = nonEmptyString(json['apiKey']);
+    final appId = nonEmptyString(json['appId']);
+    final messagingSenderId = nonEmptyString(json['messagingSenderId']);
+
+    if (projectId == null ||
+        apiKey == null ||
+        appId == null ||
+        messagingSenderId == null) {
+      return null;
+    }
+
+    return FirebaseClientConfig(
+      projectId: projectId,
+      apiKey: apiKey,
+      appId: appId,
+      messagingSenderId: messagingSenderId,
+      authDomain: nonEmptyString(json['authDomain']),
+      storageBucket: nonEmptyString(json['storageBucket']),
+    );
+  }
+}
+
+class FirebaseClientConfigDraft {
+  const FirebaseClientConfigDraft({
+    required this.projectId,
+    required this.apiKey,
+    required this.appId,
+    required this.messagingSenderId,
+    this.authDomain,
+    this.storageBucket,
+  });
+
+  final String projectId;
+  final String apiKey;
+  final String appId;
+  final String messagingSenderId;
+  final String? authDomain;
+  final String? storageBucket;
+
+  FirebaseClientConfig? validate() {
+    final projectIdValue = projectId.trim();
+    final apiKeyValue = apiKey.trim();
+    final appIdValue = appId.trim();
+    final messagingSenderIdValue = messagingSenderId.trim();
+    final authDomainValue = authDomain?.trim();
+    final storageBucketValue = storageBucket?.trim();
+
+    if (projectIdValue.isEmpty ||
+        apiKeyValue.isEmpty ||
+        appIdValue.isEmpty ||
+        messagingSenderIdValue.isEmpty) {
+      return null;
+    }
+
+    return FirebaseClientConfig(
+      projectId: projectIdValue,
+      apiKey: apiKeyValue,
+      appId: appIdValue,
+      messagingSenderId: messagingSenderIdValue,
+      authDomain: authDomainValue == null || authDomainValue.isEmpty
+          ? null
+          : authDomainValue,
+      storageBucket: storageBucketValue == null || storageBucketValue.isEmpty
+          ? null
+          : storageBucketValue,
+    );
+  }
+}

--- a/app/lib/src/services/firebase_config_store.dart
+++ b/app/lib/src/services/firebase_config_store.dart
@@ -1,0 +1,68 @@
+part of '../../main.dart';
+
+abstract class FirebaseConfigStore {
+  Future<FirebaseClientConfig?> load();
+
+  Future<bool> loadBundledConfigEnabled();
+
+  Future<void> save(FirebaseClientConfig config);
+
+  Future<void> saveBundledConfig();
+
+  Future<void> clear();
+}
+
+class SharedPreferencesFirebaseConfigStore implements FirebaseConfigStore {
+  const SharedPreferencesFirebaseConfigStore();
+
+  static const _configKey = 'remote_codex.firebase_client_config.v1';
+  static const _bundledConfigKey =
+      'remote_codex.firebase_bundled_config_enabled.v1';
+
+  @override
+  Future<FirebaseClientConfig?> load() async {
+    final preferences = await SharedPreferences.getInstance();
+    final raw = preferences.getString(_configKey);
+    if (raw == null || raw.trim().isEmpty) {
+      return null;
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) {
+        return FirebaseClientConfig.fromJson(decoded);
+      }
+    } on FormatException {
+      return null;
+    }
+
+    return null;
+  }
+
+  @override
+  Future<bool> loadBundledConfigEnabled() async {
+    final preferences = await SharedPreferences.getInstance();
+    return preferences.getBool(_bundledConfigKey) ?? false;
+  }
+
+  @override
+  Future<void> save(FirebaseClientConfig config) async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.setString(_configKey, jsonEncode(config.toJson()));
+    await preferences.remove(_bundledConfigKey);
+  }
+
+  @override
+  Future<void> saveBundledConfig() async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.remove(_configKey);
+    await preferences.setBool(_bundledConfigKey, true);
+  }
+
+  @override
+  Future<void> clear() async {
+    final preferences = await SharedPreferences.getInstance();
+    await preferences.remove(_configKey);
+    await preferences.remove(_bundledConfigKey);
+  }
+}

--- a/app/lib/src/views/firebase_setup_view.dart
+++ b/app/lib/src/views/firebase_setup_view.dart
@@ -1,0 +1,190 @@
+part of '../../main.dart';
+
+class FirebaseSetupView extends StatefulWidget {
+  const FirebaseSetupView({
+    super.key,
+    required this.onConfigured,
+    required this.onUseBundledConfig,
+  });
+
+  final Future<void> Function(FirebaseClientConfig? config) onConfigured;
+  final Future<void> Function() onUseBundledConfig;
+
+  @override
+  State<FirebaseSetupView> createState() => _FirebaseSetupViewState();
+}
+
+class _FirebaseSetupViewState extends State<FirebaseSetupView> {
+  final projectIdController = TextEditingController();
+  final apiKeyController = TextEditingController();
+  final appIdController = TextEditingController();
+  final messagingSenderIdController = TextEditingController();
+  final authDomainController = TextEditingController();
+  final storageBucketController = TextEditingController();
+  bool isSaving = false;
+  String? errorText;
+
+  @override
+  void dispose() {
+    projectIdController.dispose();
+    apiKeyController.dispose();
+    appIdController.dispose();
+    messagingSenderIdController.dispose();
+    authDomainController.dispose();
+    storageBucketController.dispose();
+    super.dispose();
+  }
+
+  Future<void> saveRuntimeConfig() async {
+    final config = FirebaseClientConfigDraft(
+      projectId: projectIdController.text,
+      apiKey: apiKeyController.text,
+      appId: appIdController.text,
+      messagingSenderId: messagingSenderIdController.text,
+      authDomain: authDomainController.text,
+      storageBucket: storageBucketController.text,
+    ).validate();
+
+    if (config == null) {
+      setState(() {
+        errorText = 'Project ID, API key, app ID, and sender ID are required.';
+      });
+      return;
+    }
+
+    await start(config);
+  }
+
+  Future<void> start(FirebaseClientConfig? config) async {
+    setState(() {
+      isSaving = true;
+      errorText = null;
+    });
+
+    try {
+      await widget.onConfigured(config);
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          isSaving = false;
+          errorText = error.toString();
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('RemoteCodex')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            Text('Firebase setup', style: theme.textTheme.headlineSmall),
+            const SizedBox(height: 8),
+            Text(
+              'Enter the Firebase web or Android client values for your own project. Do not paste service account JSON or Admin SDK credentials here.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 20),
+            _SetupTextField(
+              controller: projectIdController,
+              label: 'Project ID',
+              hintText: 'my-firebase-project',
+            ),
+            _SetupTextField(
+              controller: apiKeyController,
+              label: 'API key',
+              hintText: 'AIza...',
+            ),
+            _SetupTextField(
+              controller: appIdController,
+              label: 'App ID',
+              hintText: '1:1234567890:android:abcdef',
+            ),
+            _SetupTextField(
+              controller: messagingSenderIdController,
+              label: 'Messaging sender ID',
+              keyboardType: TextInputType.number,
+            ),
+            _SetupTextField(
+              controller: authDomainController,
+              label: 'Auth domain (optional)',
+              hintText: 'my-firebase-project.firebaseapp.com',
+            ),
+            _SetupTextField(
+              controller: storageBucketController,
+              label: 'Storage bucket (optional)',
+              hintText: 'my-firebase-project.appspot.com',
+            ),
+            if (errorText != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                errorText!,
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
+            ],
+            const SizedBox(height: 16),
+            FilledButton.icon(
+              onPressed: isSaving ? null : saveRuntimeConfig,
+              icon: isSaving
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.cloud_done),
+              label: const Text('Save and connect'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton.icon(
+              onPressed: isSaving ? null : widget.onUseBundledConfig,
+              icon: const Icon(Icons.phone_android),
+              label: const Text('Use bundled Firebase config'),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'The bundled option is for developer builds that already include google-services.json. Runtime setup is required for APK-only distribution to another Firebase project.',
+              style: theme.textTheme.bodySmall,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SetupTextField extends StatelessWidget {
+  const _SetupTextField({
+    required this.controller,
+    required this.label,
+    this.hintText,
+    this.keyboardType,
+  });
+
+  final TextEditingController controller;
+  final String label;
+  final String? hintText;
+  final TextInputType? keyboardType;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: TextField(
+        controller: controller,
+        keyboardType: keyboardType,
+        autocorrect: false,
+        enableSuggestions: false,
+        decoration: InputDecoration(
+          labelText: label,
+          hintText: hintText,
+          border: const OutlineInputBorder(),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/views/session_list_view.dart
+++ b/app/lib/src/views/session_list_view.dart
@@ -5,10 +5,12 @@ class SessionListView extends StatefulWidget {
     super.key,
     required this.bootstrap,
     required this.sessionRepository,
+    this.firebaseConfigStore,
   });
 
   final AppBootstrap bootstrap;
   final SessionRepository sessionRepository;
+  final FirebaseConfigStore? firebaseConfigStore;
 
   @override
   State<SessionListView> createState() => _SessionListViewState();
@@ -269,6 +271,7 @@ class _SessionListViewState extends State<SessionListView> {
                       child: _ConnectionSummary(
                         bootstrap: widget.bootstrap,
                         sessionRepository: widget.sessionRepository,
+                        firebaseConfigStore: widget.firebaseConfigStore,
                       ),
                     ),
                   ),

--- a/app/lib/src/widgets/connection_widgets.dart
+++ b/app/lib/src/widgets/connection_widgets.dart
@@ -4,10 +4,12 @@ class _ConnectionSummary extends StatefulWidget {
   const _ConnectionSummary({
     required this.bootstrap,
     required this.sessionRepository,
+    this.firebaseConfigStore,
   });
 
   final AppBootstrap bootstrap;
   final SessionRepository sessionRepository;
+  final FirebaseConfigStore? firebaseConfigStore;
 
   @override
   State<_ConnectionSummary> createState() => _ConnectionSummaryState();
@@ -22,6 +24,7 @@ class _ConnectionSummaryState extends State<_ConnectionSummary> {
       builder: (context) => _ConnectionSettingsSheet(
         bootstrap: widget.bootstrap,
         sessionRepository: widget.sessionRepository,
+        firebaseConfigStore: widget.firebaseConfigStore,
       ),
     );
   }
@@ -89,10 +92,12 @@ class _ConnectionSettingsSheet extends StatefulWidget {
   const _ConnectionSettingsSheet({
     required this.bootstrap,
     required this.sessionRepository,
+    this.firebaseConfigStore,
   });
 
   final AppBootstrap bootstrap;
   final SessionRepository sessionRepository;
+  final FirebaseConfigStore? firebaseConfigStore;
 
   @override
   State<_ConnectionSettingsSheet> createState() =>
@@ -102,6 +107,7 @@ class _ConnectionSettingsSheet extends StatefulWidget {
 class _ConnectionSettingsSheetState extends State<_ConnectionSettingsSheet> {
   bool isCheckingBridge = false;
   bool isOpeningDefaults = false;
+  bool isResettingFirebase = false;
   String? checkError;
 
   Future<void> requestHealthCheck() async {
@@ -165,6 +171,32 @@ class _ConnectionSettingsSheetState extends State<_ConnectionSettingsSheet> {
     );
   }
 
+  Future<void> resetFirebaseSetup() async {
+    final store = widget.firebaseConfigStore;
+    if (store == null || isResettingFirebase) {
+      return;
+    }
+
+    setState(() => isResettingFirebase = true);
+    try {
+      await store.clear();
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Firebase setup was cleared. Restart the app to set it up again.',
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => isResettingFirebase = false);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
@@ -199,6 +231,10 @@ class _ConnectionSettingsSheetState extends State<_ConnectionSettingsSheet> {
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
                 const SizedBox(height: 8),
+                Text(
+                  'Firebase project: ${widget.bootstrap.firebaseConfig?.projectId ?? 'bundled'}',
+                ),
+                const SizedBox(height: 4),
                 Text(
                   '${l10n.t('pcBridge')}: ${widget.bootstrap.pcBridgeId}${bridge.status == null ? '' : ' (${bridge.status})'}',
                 ),
@@ -268,6 +304,22 @@ class _ConnectionSettingsSheetState extends State<_ConnectionSettingsSheet> {
                               : l10n.t('cliDefaults'),
                         ),
                       ),
+                      if (widget.firebaseConfigStore != null)
+                        OutlinedButton.icon(
+                          onPressed: isResettingFirebase
+                              ? null
+                              : resetFirebaseSetup,
+                          icon: isResettingFirebase
+                              ? const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                  ),
+                                )
+                              : const Icon(Icons.restart_alt),
+                          label: const Text('Reset Firebase setup'),
+                        ),
                     ],
                   ),
                 ),

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   file_picker:
     dependency: "direct main"
     description:
@@ -357,6 +365,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -365,6 +397,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -373,6 +413,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   firebase_messaging: ^16.2.0
   flutter_local_notifications: ^21.0.0
   file_picker: ^11.0.2
+  shared_preferences: ^2.5.5
 
 dev_dependencies:
   flutter_test:

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -30,6 +30,77 @@ void main() {
     expect(sessionIdFromMessageData({'sessionId': 'session-2'}), 'session-2');
   });
 
+  test('validates runtime Firebase client config', () {
+    final invalid = const FirebaseClientConfigDraft(
+      projectId: 'project',
+      apiKey: '',
+      appId: '1:123:android:abc',
+      messagingSenderId: '123',
+    ).validate();
+
+    final valid = const FirebaseClientConfigDraft(
+      projectId: ' project ',
+      apiKey: ' key ',
+      appId: ' app ',
+      messagingSenderId: ' sender ',
+      authDomain: ' ',
+      storageBucket: ' bucket ',
+    ).validate();
+
+    expect(invalid, isNull);
+    expect(valid?.projectId, 'project');
+    expect(valid?.apiKey, 'key');
+    expect(valid?.appId, 'app');
+    expect(valid?.messagingSenderId, 'sender');
+    expect(valid?.authDomain, isNull);
+    expect(valid?.storageBucket, 'bucket');
+  });
+
+  testWidgets('shows Firebase setup before bootstrapping without config', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1400));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    FirebaseClientConfig? savedConfig;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FirebaseSetupView(
+          onConfigured: (config) async {
+            savedConfig = config;
+          },
+          onUseBundledConfig: () async {},
+        ),
+      ),
+    );
+
+    expect(find.text('Firebase setup'), findsOneWidget);
+    expect(find.text('Save and connect'), findsOneWidget);
+    expect(find.text('Use bundled Firebase config'), findsOneWidget);
+
+    await tester.tap(find.text('Save and connect'));
+    await pumpFrames(tester);
+    expect(
+      find.text('Project ID, API key, app ID, and sender ID are required.'),
+      findsOneWidget,
+    );
+
+    await tester.enterText(find.widgetWithText(TextField, 'Project ID'), 'p');
+    await tester.enterText(find.widgetWithText(TextField, 'API key'), 'k');
+    await tester.enterText(find.widgetWithText(TextField, 'App ID'), 'a');
+    await tester.enterText(
+      find.widgetWithText(TextField, 'Messaging sender ID'),
+      's',
+    );
+    await tester.tap(find.text('Save and connect'));
+    await pumpFrames(tester);
+
+    expect(savedConfig?.projectId, 'p');
+    expect(savedConfig?.apiKey, 'k');
+    expect(savedConfig?.appId, 'a');
+    expect(savedConfig?.messagingSenderId, 's');
+  });
+
   testWidgets('shows empty session list after anonymous auth baseline', (
     tester,
   ) async {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,6 +273,18 @@ NotificationService
 
 Viewは `SessionRepository` のstreamを購読し、Firestore document pathやtimestamp変換を直接扱わない。RepositoryはFirebase/Firestore SDKの型を受け持ち、Modelへ変換してViewへ渡す。
 
+## Android Firebase接続先セットアップ
+
+#101では、APK単体配布へ近づけるため、提案Bの「アプリ内セットアップ画面でFirebase接続先を登録する」方式を採用する。
+
+初回起動時、端末内にFirebase接続情報が保存されていない場合は、Firebase初期化より前にセットアップ画面を表示する。利用者は自分のFirebase project ID、API key、app ID、messaging sender IDを入力し、アプリはそれを端末内の `SharedPreferences` に保存する。保存済み設定がある場合は、その値からruntime `FirebaseOptions` を組み立てて `Firebase.initializeApp(options: ...)` を実行する。
+
+AndroidアプリにはFirebase Admin SDK credentialやservice account JSONを入力・保存しない。セットアップ画面でも、service account JSONやAdmin SDK credentialを貼り付けない注意書きを表示する。PCブリッジ側のservice account JSONと `ownerUserId` は、引き続きPC側ローカル設定だけで管理する。
+
+開発者ビルドでは、既存の `google-services.json` を使うための「bundled Firebase config」起動も残す。この経路は開発・検証用であり、利用者ごとのAPK単体配布ではruntime設定入力を使う。
+
+接続設定モーダルでは、現在のFirebase project IDを表示し、保存済みFirebase設定をクリアする導線を提供する。Firebase SDKは既定アプリ初期化後に接続先を安全に差し替えられないため、クリア後はアプリ再起動時にセットアップ画面へ戻る。
+
 ### Android表示言語
 
 Flutterの `MaterialApp.supportedLocales` と localization delegate で端末言語を解決する。


### PR DESCRIPTION
## Summary
- 初回起動時にFirebase接続情報が未保存なら、Firebase初期化前にセットアップ画面を表示するようにしました。
- 利用者自身の project ID / API key / app ID / messaging sender ID を `SharedPreferences` に保存し、runtime `FirebaseOptions` で初期化できるようにしました。
- 開発者ビルド用に bundled `google-services.json` を使う選択肢を残し、その選択も保存するようにしました。
- 接続設定モーダルでFirebase project表示とセットアップリセット導線を追加しました。
- `docs/architecture.md` に #101 の採用方針、保存対象、service account JSONを保存しない境界、リセット時の再起動前提を追記しました。

## Validation
- `flutter analyze`
- `flutter test`
- `flutter build apk --debug`
- `git diff --check`（CRLF警告のみ）

Closes #101