### PR TITLE
PCセットアップUIに言語切替を追加する

### DIFF
--- a/pc-bridge/README.md
+++ b/pc-bridge/README.md
@@ -407,6 +407,9 @@ checks, and Android setup QR generation. The service account JSON check runs in
 the browser for setup progress only. It is not sent to the QR generator and is
 not included in the QR payload.
 
+The setup UI can switch between English, Japanese, and Chinese. The selected
+language is saved in the browser with the other local setup inputs.
+
 To avoid typing the Android Firebase client values on the phone, generate a QR
 code from `google-services.json` on the PC:
 

--- a/pc-bridge/setup-web/app.js
+++ b/pc-bridge/setup-web/app.js
@@ -1,7 +1,222 @@
 const storageKey = "codexRemoteSetup.v1";
 
+const messages = {
+  en: {
+    appTitle: "Codex Remote Setup",
+    appSubtitle:
+      "Prepare Firebase, register local setup files, and generate the Android setup QR.",
+    languageLabel: "Language",
+    cloudLinksTitle: "Cloud Links",
+    cloudLinksSubtitle:
+      "Open the services needed for project creation and deployment.",
+    firebaseConsoleDesc: "Create the project and register the Android app.",
+    gcpConsoleDesc: "Check billing, APIs, IAM, and service accounts.",
+    functionsApiDesc: "Enable APIs required by Firebase Functions.",
+    firebaseCliDesc: "Install and authenticate the Firebase CLI.",
+    procedureTitle: "Procedure",
+    procedureSubtitle: "Follow these steps before scanning the QR on Android.",
+    step1: "Create a dedicated Firebase project.",
+    step2: "Enable Authentication and Anonymous sign-in.",
+    step3: "Create Firestore Database.",
+    step4Prefix: "Register Android app package",
+    step5Prefix: "Download",
+    step6: "Create a PC bridge service account JSON and keep it local only.",
+    step7: "Generate the QR and scan it from the Android setup screen.",
+    step8: "Deploy Firestore rules, indexes, and Functions when needed.",
+    projectInputsTitle: "Project Inputs",
+    projectInputsSubtitle: "These values are saved only in this browser.",
+    appNameLabel: "App name",
+    packageNameLabel: "Android package name",
+    jsonRegistrationTitle: "JSON Registration",
+    jsonRegistrationSubtitle:
+      "Use client config for the QR. Keep admin credentials on the PC side only.",
+    googleServicesDesc:
+      "This file is parsed to generate the Android QR payload.",
+    googleServicesPlaceholder: "Paste google-services.json here",
+    serviceAccountTitle: "Service account JSON",
+    serviceAccountDesc:
+      "This is checked locally for setup progress. It is not sent to the QR endpoint.",
+    dangerNotice:
+      "Never scan or share service account JSON, private keys, or Admin SDK credentials.",
+    qrGeneratorTitle: "QR Generator",
+    qrGeneratorSubtitle:
+      "Generate the same payload format used by the CLI QR command.",
+    generateQr: "Generate QR",
+    saveLocal: "Save inputs locally",
+    clearLocal: "Clear local inputs",
+    qrOutput: "QR output",
+    ready: "Ready.",
+    localStatusEmpty: "No local setup saved.",
+    notLoaded: "Not loaded.",
+    notRegistered: "Not registered.",
+    loadedFile: (name) => `Loaded ${name}.`,
+    googleServicesReady: "google-services.json text is ready.",
+    serviceAccountLooksValid: (name) =>
+      `${name} looks like a service account file. Keep it local; it will not be included in the QR.`,
+    serviceAccountLooksInvalid: (name) =>
+      `${name} was loaded, but it does not look like a service account JSON.`,
+    invalidJson: (message) => `Invalid JSON: ${message}`,
+    generatingQr: "Generating QR...",
+    qrGeneratingBox: "Generating...",
+    qrGenerated:
+      "QR generated. Scan it from the Android Firebase setup screen.",
+    qrFailed: "QR generation failed.",
+    inputsSaved: "Inputs saved in this browser.",
+    inputsCleared: "Local inputs cleared.",
+    googleServicesRestored: "Restored google-services.json text.",
+    inputsRestored: "Inputs restored from this browser.",
+    payloadFields: {
+      schema: "schema",
+      projectId: "projectId",
+      apiKey: "apiKey",
+      appId: "appId",
+      messagingSenderId: "messagingSenderId",
+      storageBucket: "storageBucket",
+    },
+  },
+  ja: {
+    appTitle: "Codex Remote セットアップ",
+    appSubtitle:
+      "Firebaseの準備、ローカル設定ファイルの確認、AndroidセットアップQRの生成を行います。",
+    languageLabel: "表示言語",
+    cloudLinksTitle: "クラウドリンク",
+    cloudLinksSubtitle: "プロジェクト作成とデプロイに必要なサービスを開きます。",
+    firebaseConsoleDesc: "プロジェクト作成とAndroidアプリ登録を行います。",
+    gcpConsoleDesc: "課金、API、IAM、サービスアカウントを確認します。",
+    functionsApiDesc: "Firebase Functionsに必要なAPIを有効化します。",
+    firebaseCliDesc: "Firebase CLIの導入と認証手順を確認します。",
+    procedureTitle: "手順",
+    procedureSubtitle: "AndroidでQRを読み取る前に、この順番で準備します。",
+    step1: "専用のFirebaseプロジェクトを作成する。",
+    step2: "Authenticationで匿名ログインを有効化する。",
+    step3: "Firestore Databaseを作成する。",
+    step4Prefix: "Androidアプリのpackageを登録する:",
+    step5Prefix: "次のファイルをダウンロードする:",
+    step6: "PCブリッジ用service account JSONを作成し、PC上だけで保管する。",
+    step7: "QRを生成し、Androidのセットアップ画面から読み取る。",
+    step8: "必要に応じてFirestore Rules、Indexes、Functionsをデプロイする。",
+    projectInputsTitle: "プロジェクト入力",
+    projectInputsSubtitle: "これらの値はこのブラウザ内にだけ保存されます。",
+    appNameLabel: "アプリ名",
+    packageNameLabel: "Android package名",
+    jsonRegistrationTitle: "JSON登録",
+    jsonRegistrationSubtitle:
+      "QRにはクライアント設定だけを使います。管理者認証情報はPC側だけで扱います。",
+    googleServicesDesc:
+      "Android用QR payloadを生成するためにこのファイルを解析します。",
+    googleServicesPlaceholder: "google-services.jsonを貼り付け",
+    serviceAccountTitle: "Service account JSON",
+    serviceAccountDesc:
+      "セットアップ状況確認のためブラウザ内で確認します。QR生成APIには送信しません。",
+    dangerNotice:
+      "service account JSON、秘密鍵、Admin SDK認証情報をQR化したり共有したりしないでください。",
+    qrGeneratorTitle: "QR生成",
+    qrGeneratorSubtitle: "CLIのQRコマンドと同じpayload形式で生成します。",
+    generateQr: "QRを生成",
+    saveLocal: "入力をローカル保存",
+    clearLocal: "ローカル入力をクリア",
+    qrOutput: "QR出力",
+    ready: "準備完了。",
+    localStatusEmpty: "ローカル保存されたセットアップ情報はありません。",
+    notLoaded: "未読み込み。",
+    notRegistered: "未登録。",
+    loadedFile: (name) => `${name}を読み込みました。`,
+    googleServicesReady: "google-services.jsonの内容を利用できます。",
+    serviceAccountLooksValid: (name) =>
+      `${name}はservice accountファイルのようです。PC内だけで保管し、QRには含めません。`,
+    serviceAccountLooksInvalid: (name) =>
+      `${name}を読み込みましたが、service account JSONではないようです。`,
+    invalidJson: (message) => `JSONが不正です: ${message}`,
+    generatingQr: "QRを生成中...",
+    qrGeneratingBox: "生成中...",
+    qrGenerated: "QRを生成しました。AndroidのFirebaseセットアップ画面で読み取ってください。",
+    qrFailed: "QR生成に失敗しました。",
+    inputsSaved: "このブラウザに入力を保存しました。",
+    inputsCleared: "ローカル入力をクリアしました。",
+    googleServicesRestored: "google-services.jsonの内容を復元しました。",
+    inputsRestored: "このブラウザから入力を復元しました。",
+    payloadFields: {
+      schema: "schema",
+      projectId: "projectId",
+      apiKey: "API key",
+      appId: "app ID",
+      messagingSenderId: "messaging sender ID",
+      storageBucket: "storage bucket",
+    },
+  },
+  zh: {
+    appTitle: "Codex Remote 设置",
+    appSubtitle: "准备 Firebase、登记本地设置文件，并生成 Android 设置二维码。",
+    languageLabel: "语言",
+    cloudLinksTitle: "云服务链接",
+    cloudLinksSubtitle: "打开创建项目和部署所需的服务。",
+    firebaseConsoleDesc: "创建项目并注册 Android 应用。",
+    gcpConsoleDesc: "检查结算、API、IAM 和服务账号。",
+    functionsApiDesc: "启用 Firebase Functions 所需的 API。",
+    firebaseCliDesc: "安装 Firebase CLI 并完成认证。",
+    procedureTitle: "步骤",
+    procedureSubtitle: "在 Android 上扫描二维码前，请按以下步骤准备。",
+    step1: "创建专用的 Firebase 项目。",
+    step2: "启用 Authentication 和匿名登录。",
+    step3: "创建 Firestore Database。",
+    step4Prefix: "注册 Android 应用 package:",
+    step5Prefix: "下载文件:",
+    step6: "创建 PC 桥接用 service account JSON，并只保存在本机。",
+    step7: "生成二维码，并从 Android 设置画面扫描。",
+    step8: "按需部署 Firestore rules、indexes 和 Functions。",
+    projectInputsTitle: "项目输入",
+    projectInputsSubtitle: "这些值只保存在当前浏览器中。",
+    appNameLabel: "应用名称",
+    packageNameLabel: "Android package 名称",
+    jsonRegistrationTitle: "JSON 登记",
+    jsonRegistrationSubtitle:
+      "二维码只使用客户端配置。管理员凭据只在 PC 侧处理。",
+    googleServicesDesc: "解析此文件以生成 Android 二维码 payload。",
+    googleServicesPlaceholder: "在此粘贴 google-services.json",
+    serviceAccountTitle: "Service account JSON",
+    serviceAccountDesc:
+      "仅在浏览器内用于检查设置进度，不会发送到二维码生成接口。",
+    dangerNotice:
+      "不要扫描或共享 service account JSON、私钥或 Admin SDK 凭据。",
+    qrGeneratorTitle: "二维码生成",
+    qrGeneratorSubtitle: "生成与 CLI 二维码命令相同格式的 payload。",
+    generateQr: "生成二维码",
+    saveLocal: "保存到本地",
+    clearLocal: "清除本地输入",
+    qrOutput: "二维码输出",
+    ready: "就绪。",
+    localStatusEmpty: "没有保存的本地设置。",
+    notLoaded: "未加载。",
+    notRegistered: "未登记。",
+    loadedFile: (name) => `已加载 ${name}。`,
+    googleServicesReady: "google-services.json 文本已准备好。",
+    serviceAccountLooksValid: (name) =>
+      `${name} 看起来是 service account 文件。请保存在本机，且不会包含在二维码中。`,
+    serviceAccountLooksInvalid: (name) =>
+      `${name} 已加载，但看起来不是 service account JSON。`,
+    invalidJson: (message) => `JSON 无效: ${message}`,
+    generatingQr: "正在生成二维码...",
+    qrGeneratingBox: "生成中...",
+    qrGenerated: "二维码已生成。请在 Android Firebase 设置画面扫描。",
+    qrFailed: "二维码生成失败。",
+    inputsSaved: "输入已保存在当前浏览器中。",
+    inputsCleared: "本地输入已清除。",
+    googleServicesRestored: "已恢复 google-services.json 文本。",
+    inputsRestored: "已从当前浏览器恢复输入。",
+    payloadFields: {
+      schema: "schema",
+      projectId: "projectId",
+      apiKey: "API key",
+      appId: "app ID",
+      messagingSenderId: "messaging sender ID",
+      storageBucket: "storage bucket",
+    },
+  },
+};
+
 const appName = document.querySelector("#appName");
 const packageName = document.querySelector("#packageName");
+const languageSelect = document.querySelector("#languageSelect");
 const localStatus = document.querySelector("#localStatus");
 const googleServicesFile = document.querySelector("#googleServicesFile");
 const googleServicesText = document.querySelector("#googleServicesText");
@@ -15,20 +230,34 @@ const qrBox = document.querySelector("#qrBox");
 const payloadList = document.querySelector("#payloadList");
 const qrStatus = document.querySelector("#qrStatus");
 
+let currentLanguage = detectInitialLanguage();
+let lastPayload = null;
+
+languageSelect.value = currentLanguage;
+applyLanguage();
 loadLocalState();
+
+languageSelect.addEventListener("change", () => {
+  currentLanguage = languageSelect.value;
+  saveLocalState();
+  applyLanguage();
+  if (lastPayload) {
+    renderPayload(lastPayload);
+  }
+});
 
 googleServicesFile.addEventListener("change", async () => {
   const file = googleServicesFile.files?.[0];
   if (!file) return;
   googleServicesText.value = await file.text();
-  setStatus(googleServicesStatus, `Loaded ${file.name}.`, false);
+  setStatus(googleServicesStatus, t("loadedFile", file.name), false);
 });
 
 googleServicesText.addEventListener("input", () => {
   const value = googleServicesText.value.trim();
   setStatus(
     googleServicesStatus,
-    value ? "google-services.json text is ready." : "Not loaded.",
+    value ? t("googleServicesReady") : t("notLoaded"),
     false,
   );
 });
@@ -45,18 +274,18 @@ serviceAccountFile.addEventListener("change", async () => {
     setStatus(
       serviceAccountStatus,
       hasPrivateKey
-        ? `${file.name} looks like a service account file. Keep it local; it will not be included in the QR.`
-        : `${file.name} was loaded, but it does not look like a service account JSON.`,
+        ? t("serviceAccountLooksValid", file.name)
+        : t("serviceAccountLooksInvalid", file.name),
       !hasPrivateKey,
     );
   } catch (error) {
-    setStatus(serviceAccountStatus, `Invalid JSON: ${error.message}`, true);
+    setStatus(serviceAccountStatus, t("invalidJson", error.message), true);
   }
 });
 
 generateQr.addEventListener("click", async () => {
-  setStatus(qrStatus, "Generating QR...", false);
-  qrBox.replaceChildren(document.createTextNode("Generating..."));
+  setStatus(qrStatus, t("generatingQr"), false);
+  qrBox.replaceChildren(document.createTextNode(t("qrGeneratingBox")));
   payloadList.replaceChildren();
 
   try {
@@ -70,42 +299,36 @@ generateQr.addEventListener("click", async () => {
     });
     const result = await response.json();
     if (!response.ok) {
-      throw new Error(result.error ?? "QR generation failed.");
+      throw new Error(result.error ?? t("qrFailed"));
     }
 
     const image = document.createElement("img");
     image.src = result.qrDataUrl;
     image.alt = "Firebase setup QR";
     qrBox.replaceChildren(image);
+    lastPayload = result.payload;
     renderPayload(result.payload);
-    setStatus(
-      qrStatus,
-      "QR generated. Scan it from the Android Firebase setup screen.",
-      false,
-    );
+    setStatus(qrStatus, t("qrGenerated"), false);
   } catch (error) {
-    qrBox.replaceChildren(document.createTextNode("QR output"));
+    qrBox.replaceChildren(document.createTextNode(t("qrOutput")));
     setStatus(qrStatus, error.message, true);
   }
 });
 
 saveLocal.addEventListener("click", () => {
-  localStorage.setItem(
-    storageKey,
-    JSON.stringify({
-      appName: appName.value,
-      packageName: packageName.value,
-      googleServicesText: googleServicesText.value,
-    }),
-  );
-  setStatus(localStatus, "Inputs saved in this browser.", false);
+  saveLocalState();
+  setStatus(localStatus, t("inputsSaved"), false);
 });
 
 clearLocal.addEventListener("click", () => {
   localStorage.removeItem(storageKey);
   googleServicesText.value = "";
-  setStatus(localStatus, "Local inputs cleared.", false);
-  setStatus(googleServicesStatus, "Not loaded.", false);
+  lastPayload = null;
+  payloadList.replaceChildren();
+  qrBox.replaceChildren(document.createTextNode(t("qrOutput")));
+  setStatus(localStatus, t("inputsCleared"), false);
+  setStatus(googleServicesStatus, t("notLoaded"), false);
+  setStatus(qrStatus, t("ready"), false);
 });
 
 function loadLocalState() {
@@ -114,28 +337,81 @@ function loadLocalState() {
 
   try {
     const state = JSON.parse(raw);
+    if (typeof state.language === "string" && messages[state.language]) {
+      currentLanguage = state.language;
+      languageSelect.value = currentLanguage;
+      applyLanguage();
+    }
     if (typeof state.appName === "string") appName.value = state.appName;
     if (typeof state.packageName === "string") {
       packageName.value = state.packageName;
     }
     if (typeof state.googleServicesText === "string") {
       googleServicesText.value = state.googleServicesText;
-      setStatus(googleServicesStatus, "Restored google-services.json text.", false);
+      setStatus(googleServicesStatus, t("googleServicesRestored"), false);
     }
-    setStatus(localStatus, "Inputs restored from this browser.", false);
+    setStatus(localStatus, t("inputsRestored"), false);
   } catch {
     localStorage.removeItem(storageKey);
   }
 }
 
+function saveLocalState() {
+  localStorage.setItem(
+    storageKey,
+    JSON.stringify({
+      language: currentLanguage,
+      appName: appName.value,
+      packageName: packageName.value,
+      googleServicesText: googleServicesText.value,
+    }),
+  );
+}
+
+function applyLanguage() {
+  document.documentElement.lang = currentLanguage;
+  for (const element of document.querySelectorAll("[data-i18n]")) {
+    element.textContent = t(element.dataset.i18n);
+  }
+  for (const element of document.querySelectorAll("[data-i18n-placeholder]")) {
+    element.placeholder = t(element.dataset.i18nPlaceholder);
+  }
+  if (!googleServicesText.value.trim()) {
+    setStatus(googleServicesStatus, t("notLoaded"), false);
+  }
+  if (!serviceAccountFile.files?.length) {
+    setStatus(serviceAccountStatus, t("notRegistered"), false);
+  }
+}
+
+function detectInitialLanguage() {
+  const raw = localStorage.getItem(storageKey);
+  if (raw) {
+    try {
+      const state = JSON.parse(raw);
+      if (typeof state.language === "string" && messages[state.language]) {
+        return state.language;
+      }
+    } catch {
+      localStorage.removeItem(storageKey);
+    }
+  }
+
+  const browserLanguage = navigator.language.toLowerCase();
+  if (browserLanguage.startsWith("ja")) return "ja";
+  if (browserLanguage.startsWith("zh")) return "zh";
+  return "en";
+}
+
 function renderPayload(payload) {
+  const labels = messages[currentLanguage].payloadFields;
   const rows = [
-    ["schema", payload.schema],
-    ["projectId", payload.projectId],
-    ["apiKey", maskValue(payload.apiKey)],
-    ["appId", payload.appId],
-    ["messagingSenderId", payload.messagingSenderId],
-    ["storageBucket", payload.storageBucket ?? ""],
+    [labels.schema, payload.schema],
+    [labels.projectId, payload.projectId],
+    [labels.apiKey, maskValue(payload.apiKey)],
+    [labels.appId, payload.appId],
+    [labels.messagingSenderId, payload.messagingSenderId],
+    [labels.storageBucket, payload.storageBucket ?? ""],
   ];
 
   payloadList.replaceChildren();
@@ -156,4 +432,9 @@ function maskValue(value) {
 function setStatus(element, message, isError) {
   element.textContent = message;
   element.classList.toggle("error", isError);
+}
+
+function t(key, ...args) {
+  const value = messages[currentLanguage][key] ?? messages.en[key] ?? key;
+  return typeof value === "function" ? value(...args) : value;
 }

--- a/pc-bridge/setup-web/index.html
+++ b/pc-bridge/setup-web/index.html
@@ -9,90 +9,100 @@
   <body>
     <header class="topbar">
       <div>
-        <h1>Codex Remote Setup</h1>
-        <p>Prepare Firebase, register local setup files, and generate the Android setup QR.</p>
+        <h1 data-i18n="appTitle">Codex Remote Setup</h1>
+        <p data-i18n="appSubtitle">Prepare Firebase, register local setup files, and generate the Android setup QR.</p>
       </div>
-      <a class="button secondary" href="https://console.firebase.google.com/" target="_blank" rel="noreferrer">Firebase Console</a>
+      <div class="top-actions">
+        <label class="language-label">
+          <span data-i18n="languageLabel">Language</span>
+          <select id="languageSelect">
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+            <option value="zh">中文</option>
+          </select>
+        </label>
+        <a class="button secondary" href="https://console.firebase.google.com/" target="_blank" rel="noreferrer">Firebase Console</a>
+      </div>
     </header>
 
     <main class="layout">
       <section class="panel span-2">
         <div class="section-heading">
-          <h2>Cloud Links</h2>
-          <p>Open the services needed for project creation and deployment.</p>
+          <h2 data-i18n="cloudLinksTitle">Cloud Links</h2>
+          <p data-i18n="cloudLinksSubtitle">Open the services needed for project creation and deployment.</p>
         </div>
         <div class="link-grid">
           <a href="https://console.firebase.google.com/" target="_blank" rel="noreferrer">
             <strong>Firebase Console</strong>
-            <span>Create the project and register the Android app.</span>
+            <span data-i18n="firebaseConsoleDesc">Create the project and register the Android app.</span>
           </a>
           <a href="https://console.cloud.google.com/" target="_blank" rel="noreferrer">
             <strong>Google Cloud Console</strong>
-            <span>Check billing, APIs, IAM, and service accounts.</span>
+            <span data-i18n="gcpConsoleDesc">Check billing, APIs, IAM, and service accounts.</span>
           </a>
           <a href="https://console.cloud.google.com/apis/library/cloudfunctions.googleapis.com" target="_blank" rel="noreferrer">
             <strong>Cloud Functions API</strong>
-            <span>Enable APIs required by Firebase Functions.</span>
+            <span data-i18n="functionsApiDesc">Enable APIs required by Firebase Functions.</span>
           </a>
           <a href="https://firebase.google.com/docs/cli" target="_blank" rel="noreferrer">
             <strong>Firebase CLI Docs</strong>
-            <span>Install and authenticate the Firebase CLI.</span>
+            <span data-i18n="firebaseCliDesc">Install and authenticate the Firebase CLI.</span>
           </a>
         </div>
       </section>
 
       <section class="panel">
         <div class="section-heading">
-          <h2>Procedure</h2>
-          <p>Follow these steps before scanning the QR on Android.</p>
+          <h2 data-i18n="procedureTitle">Procedure</h2>
+          <p data-i18n="procedureSubtitle">Follow these steps before scanning the QR on Android.</p>
         </div>
         <ol class="steps">
-          <li>Create a dedicated Firebase project.</li>
-          <li>Enable Authentication and Anonymous sign-in.</li>
-          <li>Create Firestore Database.</li>
-          <li>Register Android app package <code>com.sunmax.remotecodex</code>.</li>
-          <li>Download <code>google-services.json</code>.</li>
-          <li>Create a PC bridge service account JSON and keep it local only.</li>
-          <li>Generate the QR and scan it from the Android setup screen.</li>
-          <li>Deploy Firestore rules, indexes, and Functions when needed.</li>
+          <li data-i18n="step1">Create a dedicated Firebase project.</li>
+          <li data-i18n="step2">Enable Authentication and Anonymous sign-in.</li>
+          <li data-i18n="step3">Create Firestore Database.</li>
+          <li><span data-i18n="step4Prefix">Register Android app package</span> <code>com.sunmax.remotecodex</code>.</li>
+          <li><span data-i18n="step5Prefix">Download</span> <code>google-services.json</code>.</li>
+          <li data-i18n="step6">Create a PC bridge service account JSON and keep it local only.</li>
+          <li data-i18n="step7">Generate the QR and scan it from the Android setup screen.</li>
+          <li data-i18n="step8">Deploy Firestore rules, indexes, and Functions when needed.</li>
         </ol>
       </section>
 
       <section class="panel">
         <div class="section-heading">
-          <h2>Project Inputs</h2>
-          <p>These values are saved only in this browser.</p>
+          <h2 data-i18n="projectInputsTitle">Project Inputs</h2>
+          <p data-i18n="projectInputsSubtitle">These values are saved only in this browser.</p>
         </div>
         <label>
-          App name
+          <span data-i18n="appNameLabel">App name</span>
           <input id="appName" autocomplete="off" value="RemoteCodex" />
         </label>
         <label>
-          Android package name
+          <span data-i18n="packageNameLabel">Android package name</span>
           <input id="packageName" autocomplete="off" value="com.sunmax.remotecodex" />
         </label>
-        <div class="status-line" id="localStatus">No local setup saved.</div>
+        <div class="status-line" id="localStatus" data-i18n="localStatusEmpty">No local setup saved.</div>
       </section>
 
       <section class="panel span-2">
         <div class="section-heading">
-          <h2>JSON Registration</h2>
-          <p>Use client config for the QR. Keep admin credentials on the PC side only.</p>
+          <h2 data-i18n="jsonRegistrationTitle">JSON Registration</h2>
+          <p data-i18n="jsonRegistrationSubtitle">Use client config for the QR. Keep admin credentials on the PC side only.</p>
         </div>
         <div class="two-column">
           <div>
             <h3>google-services.json</h3>
-            <p class="muted">This file is parsed to generate the Android QR payload.</p>
+            <p class="muted" data-i18n="googleServicesDesc">This file is parsed to generate the Android QR payload.</p>
             <input id="googleServicesFile" type="file" accept=".json,application/json" />
-            <textarea id="googleServicesText" spellcheck="false" placeholder="Paste google-services.json here"></textarea>
-            <div class="status-line" id="googleServicesStatus">Not loaded.</div>
+            <textarea id="googleServicesText" spellcheck="false" data-i18n-placeholder="googleServicesPlaceholder" placeholder="Paste google-services.json here"></textarea>
+            <div class="status-line" id="googleServicesStatus" data-i18n="notLoaded">Not loaded.</div>
           </div>
           <div>
-            <h3>Service account JSON</h3>
-            <p class="muted">This is checked locally for setup progress. It is not sent to the QR endpoint.</p>
+            <h3 data-i18n="serviceAccountTitle">Service account JSON</h3>
+            <p class="muted" data-i18n="serviceAccountDesc">This is checked locally for setup progress. It is not sent to the QR endpoint.</p>
             <input id="serviceAccountFile" type="file" accept=".json,application/json" />
-            <div class="status-line" id="serviceAccountStatus">Not registered.</div>
-            <div class="notice danger">
+            <div class="status-line" id="serviceAccountStatus" data-i18n="notRegistered">Not registered.</div>
+            <div class="notice danger" data-i18n="dangerNotice">
               Never scan or share service account JSON, private keys, or Admin SDK credentials.
             </div>
           </div>
@@ -101,21 +111,21 @@
 
       <section class="panel span-2">
         <div class="section-heading">
-          <h2>QR Generator</h2>
-          <p>Generate the same payload format used by the CLI QR command.</p>
+          <h2 data-i18n="qrGeneratorTitle">QR Generator</h2>
+          <p data-i18n="qrGeneratorSubtitle">Generate the same payload format used by the CLI QR command.</p>
         </div>
         <div class="actions">
-          <button id="generateQr" class="button primary">Generate QR</button>
-          <button id="saveLocal" class="button secondary">Save inputs locally</button>
-          <button id="clearLocal" class="button ghost">Clear local inputs</button>
+          <button id="generateQr" class="button primary" data-i18n="generateQr">Generate QR</button>
+          <button id="saveLocal" class="button secondary" data-i18n="saveLocal">Save inputs locally</button>
+          <button id="clearLocal" class="button ghost" data-i18n="clearLocal">Clear local inputs</button>
         </div>
         <div class="qr-area">
           <div class="qr-box" id="qrBox">
-            <span>QR output</span>
+            <span data-i18n="qrOutput">QR output</span>
           </div>
           <dl class="payload-list" id="payloadList"></dl>
         </div>
-        <div class="status-line" id="qrStatus">Ready.</div>
+        <div class="status-line" id="qrStatus" data-i18n="ready">Ready.</div>
       </section>
     </main>
 

--- a/pc-bridge/setup-web/styles.css
+++ b/pc-bridge/setup-web/styles.css
@@ -52,6 +52,35 @@ body {
   border-bottom: 1px solid var(--line);
 }
 
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.language-label {
+  min-width: 150px;
+  margin: 0;
+}
+
+.language-label span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+select {
+  width: 100%;
+  padding: 8px 10px;
+  color: var(--text);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font: inherit;
+}
+
 h1,
 h2,
 h3,
@@ -291,6 +320,7 @@ code {
 
 @media (max-width: 860px) {
   .topbar,
+  .top-actions,
   .layout,
   .two-column,
   .qr-area,
@@ -299,6 +329,7 @@ code {
   }
 
   .topbar > a,
+  .top-actions > a,
   .panel,
   .link-grid a,
   .two-column > div + div {


### PR DESCRIPTION
## Summary
- PC側セットアップWeb UIに日本語・英語・中国語の言語切替を追加しました。
- クラウドリンク、手順、入力ラベル、ボタン、注意文、ステータスメッセージを翻訳対象にしました。
- 選択言語を既存のlocalStorage設定へ保存し、再読み込み後も維持するようにしました。
- QR生成後のpayload表示ラベルも選択言語に合わせて更新します。

## Validation
- `npm.cmd run check`
- `GET http://127.0.0.1:8787/index.html` が 200 を返し、言語セレクタを含むことを確認
- `GET http://127.0.0.1:8787/app.js` が日本語・中国語文言を含むことを確認
- `POST http://127.0.0.1:8787/api/firebase-setup-qr` のQR生成回帰確認
- `git diff --check`（CRLF警告のみ）

Closes #117