### PR TITLE
PCセットアップUIを配布APKの固定設定に合わせる

### DIFF
--- a/pc-bridge/setup-web/app.js
+++ b/pc-bridge/setup-web/app.js
@@ -1,4 +1,6 @@
 const storageKey = "codexRemoteSetup.v1";
+const fixedAppName = "RemoteCodex";
+const fixedPackageName = "com.sunmax.remotecodex";
 
 const messages = {
   en: {
@@ -18,24 +20,14 @@ const messages = {
     step1: "Create a dedicated Firebase project.",
     step2: "Enable Authentication and Anonymous sign-in.",
     step3: "Create Firestore Database.",
-    step4: "Register Android app package. Example: com.sample.remotecodex.",
+    step4: "Register Android app package: com.sunmax.remotecodex.",
     step5Prefix: "Download",
     step6: "Create a PC bridge service account JSON and keep it local only.",
     step7: "Generate the QR and scan it from the Android setup screen.",
     step8: "Deploy Firestore rules, indexes, and Functions when needed.",
-    projectInputsTitle: "Project Inputs",
-    projectInputsSubtitle: "These values are saved only in this browser.",
     appNameLabel: "App name",
     packageNameLabel: "Android package name",
-    appNamePlaceholder: "RemoteCodex",
-    packageNamePlaceholder: "com.sunmax.remotecodex",
-    commandsTitle: "Command Guide",
-    commandsSubtitle:
-      "Run these from PowerShell or Command Prompt when setting up the PC side.",
-    commandInstallTitle: "Install PC dependencies",
-    commandStartUiTitle: "Start this setup UI",
-    commandDeployTitle: "Deploy Firebase resources",
-    commandQrTitle: "Generate QR from CLI",
+    fixedAppInfoTitle: "Distributed APK settings",
     jsonRegistrationTitle: "JSON Registration",
     jsonRegistrationSubtitle:
       "Use client config for the QR. Keep admin credentials on the PC side only.",
@@ -49,7 +41,7 @@ const messages = {
       "Never scan or share service account JSON, private keys, or Admin SDK credentials.",
     qrGeneratorTitle: "QR Generator",
     qrGeneratorSubtitle:
-      "Generate the same payload format used by the CLI QR command.",
+      "Generate the Android setup QR for the distributed APK.",
     generateQr: "Generate QR",
     saveLocal: "Save inputs locally",
     clearLocal: "Clear local inputs",
@@ -99,24 +91,14 @@ const messages = {
     step1: "専用のFirebaseプロジェクトを作成する。",
     step2: "Authenticationで匿名ログインを有効化する。",
     step3: "Firestore Databaseを作成する。",
-    step4: "Androidアプリのpackageを登録する（例：com.sample.remotecodex）",
+    step4: "Androidアプリのpackageを登録する: com.sunmax.remotecodex",
     step5Prefix: "次のファイルをダウンロードする:",
     step6: "PCブリッジ用service account JSONを作成し、PC上だけで保管する。",
     step7: "QRを生成し、Androidのセットアップ画面から読み取る。",
     step8: "必要に応じてFirestore Rules、Indexes、Functionsをデプロイする。",
-    projectInputsTitle: "プロジェクト入力",
-    projectInputsSubtitle: "これらの値はこのブラウザ内にだけ保存されます。",
     appNameLabel: "アプリ名",
     packageNameLabel: "Android package名",
-    appNamePlaceholder: "RemoteCodex",
-    packageNamePlaceholder: "com.sunmax.remotecodex",
-    commandsTitle: "コマンド案内",
-    commandsSubtitle:
-      "PC側のセットアップで必要なコマンドをPowerShellまたはコマンドプロンプトで実行します。",
-    commandInstallTitle: "PC側の依存関係をインストール",
-    commandStartUiTitle: "このセットアップ画面を起動",
-    commandDeployTitle: "Firebaseリソースをデプロイ",
-    commandQrTitle: "CLIでQRコードを生成",
+    fixedAppInfoTitle: "配布APKの固定設定",
     jsonRegistrationTitle: "JSON登録",
     jsonRegistrationSubtitle:
       "QRにはクライアント設定だけを使います。管理者認証情報はPC側だけで扱います。",
@@ -129,7 +111,7 @@ const messages = {
     dangerNotice:
       "service account JSON、秘密鍵、Admin SDK認証情報をQR化したり共有したりしないでください。",
     qrGeneratorTitle: "QR生成",
-    qrGeneratorSubtitle: "CLIのQRコマンドと同じpayload形式で生成します。",
+    qrGeneratorSubtitle: "配布APK向けのAndroidセットアップQRを生成します。",
     generateQr: "QRを生成",
     saveLocal: "入力をローカル保存",
     clearLocal: "ローカル入力をクリア",
@@ -177,23 +159,14 @@ const messages = {
     step1: "创建专用的 Firebase 项目。",
     step2: "启用 Authentication 和匿名登录。",
     step3: "创建 Firestore Database。",
-    step4: "注册 Android 应用 package（示例：com.sample.remotecodex）",
+    step4: "注册 Android 应用 package：com.sunmax.remotecodex",
     step5Prefix: "下载文件:",
     step6: "创建 PC 桥接用 service account JSON，并只保存在本机。",
     step7: "生成二维码，并从 Android 设置画面扫描。",
     step8: "按需部署 Firestore rules、indexes 和 Functions。",
-    projectInputsTitle: "项目输入",
-    projectInputsSubtitle: "这些值只保存在当前浏览器中。",
     appNameLabel: "应用名称",
     packageNameLabel: "Android package 名称",
-    appNamePlaceholder: "RemoteCodex",
-    packageNamePlaceholder: "com.sunmax.remotecodex",
-    commandsTitle: "命令指南",
-    commandsSubtitle: "设置 PC 端时，请在 PowerShell 或命令提示符中运行这些命令。",
-    commandInstallTitle: "安装 PC 端依赖",
-    commandStartUiTitle: "启动此设置页面",
-    commandDeployTitle: "部署 Firebase 资源",
-    commandQrTitle: "通过 CLI 生成二维码",
+    fixedAppInfoTitle: "分发 APK 的固定设置",
     jsonRegistrationTitle: "JSON 登记",
     jsonRegistrationSubtitle:
       "二维码只使用客户端配置。管理员凭据只在 PC 侧处理。",
@@ -205,7 +178,7 @@ const messages = {
     dangerNotice:
       "不要扫描或共享 service account JSON、私钥或 Admin SDK 凭据。",
     qrGeneratorTitle: "二维码生成",
-    qrGeneratorSubtitle: "生成与 CLI 二维码命令相同格式的 payload。",
+    qrGeneratorSubtitle: "为分发 APK 生成 Android 设置二维码。",
     generateQr: "生成二维码",
     saveLocal: "保存到本地",
     clearLocal: "清除本地输入",
@@ -240,8 +213,6 @@ const messages = {
   },
 };
 
-const appName = document.querySelector("#appName");
-const packageName = document.querySelector("#packageName");
 const languageSelect = document.querySelector("#languageSelect");
 const localStatus = document.querySelector("#localStatus");
 const googleServicesFile = document.querySelector("#googleServicesFile");
@@ -320,7 +291,7 @@ generateQr.addEventListener("click", async () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         googleServicesJson: googleServicesText.value,
-        packageName: packageName.value,
+        packageName: fixedPackageName,
       }),
     });
     const result = await response.json();
@@ -368,10 +339,6 @@ function loadLocalState() {
       languageSelect.value = currentLanguage;
       applyLanguage();
     }
-    if (typeof state.appName === "string") appName.value = state.appName;
-    if (typeof state.packageName === "string") {
-      packageName.value = state.packageName;
-    }
     if (typeof state.googleServicesText === "string") {
       googleServicesText.value = state.googleServicesText;
       setStatus(googleServicesStatus, t("googleServicesRestored"), false);
@@ -387,8 +354,8 @@ function saveLocalState() {
     storageKey,
     JSON.stringify({
       language: currentLanguage,
-      appName: appName.value,
-      packageName: packageName.value,
+      appName: fixedAppName,
+      packageName: fixedPackageName,
       googleServicesText: googleServicesText.value,
     }),
   );

--- a/pc-bridge/setup-web/index.html
+++ b/pc-bridge/setup-web/index.html
@@ -50,7 +50,7 @@
         </div>
       </section>
 
-      <section class="panel">
+      <section class="panel span-2">
         <div class="section-heading">
           <h2 data-i18n="procedureTitle">Procedure</h2>
           <p data-i18n="procedureSubtitle">Follow these steps before scanning the QR on Android.</p>
@@ -59,60 +59,12 @@
           <li data-i18n="step1">Create a dedicated Firebase project.</li>
           <li data-i18n="step2">Enable Authentication and Anonymous sign-in.</li>
           <li data-i18n="step3">Create Firestore Database.</li>
-          <li data-i18n="step4">Register Android app package. Example: com.sample.remotecodex.</li>
+          <li data-i18n="step4">Register Android app package: com.sunmax.remotecodex.</li>
           <li><span data-i18n="step5Prefix">Download</span> <code>google-services.json</code>.</li>
           <li data-i18n="step6">Create a PC bridge service account JSON and keep it local only.</li>
           <li data-i18n="step7">Generate the QR and scan it from the Android setup screen.</li>
           <li data-i18n="step8">Deploy Firestore rules, indexes, and Functions when needed.</li>
         </ol>
-      </section>
-
-      <section class="panel">
-        <div class="section-heading">
-          <h2 data-i18n="projectInputsTitle">Project Inputs</h2>
-          <p data-i18n="projectInputsSubtitle">These values are saved only in this browser.</p>
-        </div>
-        <label>
-          <span data-i18n="appNameLabel">App name</span>
-          <input id="appName" autocomplete="off" data-i18n-placeholder="appNamePlaceholder" placeholder="RemoteCodex" />
-        </label>
-        <label>
-          <span data-i18n="packageNameLabel">Android package name</span>
-          <input id="packageName" autocomplete="off" data-i18n-placeholder="packageNamePlaceholder" placeholder="com.sunmax.remotecodex" />
-        </label>
-        <div class="status-line" id="localStatus" data-i18n="localStatusEmpty">No local setup saved.</div>
-      </section>
-
-      <section class="panel span-2">
-        <div class="section-heading">
-          <h2 data-i18n="commandsTitle">Command Guide</h2>
-          <p data-i18n="commandsSubtitle">Run these from PowerShell or Command Prompt when setting up the PC side.</p>
-        </div>
-        <div class="command-grid">
-          <div>
-            <h3 data-i18n="commandInstallTitle">Install PC dependencies</h3>
-            <pre><code>cd pc-bridge
-npm.cmd install</code></pre>
-          </div>
-          <div>
-            <h3 data-i18n="commandStartUiTitle">Start this setup UI</h3>
-            <pre><code>cd pc-bridge
-npm.cmd run setup:web</code></pre>
-          </div>
-          <div>
-            <h3 data-i18n="commandDeployTitle">Deploy Firebase resources</h3>
-            <pre><code>cd firebase
-firebase login
-firebase use --add
-firebase deploy --only firestore:rules,firestore:indexes
-firebase deploy --only functions</code></pre>
-          </div>
-          <div>
-            <h3 data-i18n="commandQrTitle">Generate QR from CLI</h3>
-            <pre><code>cd pc-bridge
-npm.cmd run qr:firebase -- --google-services ..\app\android\app\google-services.json --package com.sample.remotecodex</code></pre>
-          </div>
-        </div>
       </section>
 
       <section class="panel span-2">
@@ -143,7 +95,16 @@ npm.cmd run qr:firebase -- --google-services ..\app\android\app\google-services.
       <section class="panel span-2">
         <div class="section-heading">
           <h2 data-i18n="qrGeneratorTitle">QR Generator</h2>
-          <p data-i18n="qrGeneratorSubtitle">Generate the same payload format used by the CLI QR command.</p>
+          <p data-i18n="qrGeneratorSubtitle">Generate the Android setup QR for the distributed APK.</p>
+        </div>
+        <div class="fixed-app-info">
+          <h3 data-i18n="fixedAppInfoTitle">Distributed APK settings</h3>
+          <dl>
+            <dt data-i18n="appNameLabel">App name</dt>
+            <dd>RemoteCodex</dd>
+            <dt data-i18n="packageNameLabel">Android package name</dt>
+            <dd><code>com.sunmax.remotecodex</code></dd>
+          </dl>
         </div>
         <div class="actions">
           <button id="generateQr" class="button primary" data-i18n="generateQr">Generate QR</button>
@@ -156,6 +117,7 @@ npm.cmd run qr:firebase -- --google-services ..\app\android\app\google-services.
           </div>
           <dl class="payload-list" id="payloadList"></dl>
         </div>
+        <div class="status-line" id="localStatus" data-i18n="localStatusEmpty">No local setup saved.</div>
         <div class="status-line" id="qrStatus" data-i18n="ready">Ready.</div>
       </section>
     </main>

--- a/pc-bridge/setup-web/styles.css
+++ b/pc-bridge/setup-web/styles.css
@@ -208,36 +208,35 @@ textarea {
   gap: 18px;
 }
 
-.command-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-}
-
-pre {
-  min-height: 92px;
-  margin: 8px 0 0;
-  padding: 12px;
-  overflow-x: auto;
-  color: var(--text);
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-}
-
-pre code {
-  padding: 0;
-  background: transparent;
-  font-family: Consolas, "Cascadia Mono", monospace;
-  font-size: 13px;
-  line-height: 1.5;
-}
-
 .actions {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
   margin-bottom: 16px;
+}
+
+.fixed-app-info {
+  margin-bottom: 16px;
+  padding: 12px;
+  background: var(--soft);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+
+.fixed-app-info dl {
+  display: grid;
+  grid-template-columns: 170px minmax(0, 1fr);
+  gap: 8px 12px;
+  margin: 0;
+}
+
+.fixed-app-info dt {
+  color: var(--muted);
+}
+
+.fixed-app-info dd {
+  margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .button,
@@ -348,7 +347,6 @@ code {
   .top-actions,
   .layout,
   .two-column,
-  .command-grid,
   .qr-area,
   .link-grid {
     display: block;


### PR DESCRIPTION
Closes #121

## Summary
- プロジェクト入力セクションを削除
- QR生成セクションに配布APKの固定アプリ名とpackage名を表示
- QR生成時は固定package名 com.sunmax.remotecodex を使用
- 手順内で入力タイミングのないコマンド案内セクションを削除
- サンプルpackage表記を配布APKのpackage名に修正

## Verification
- npm.cmd run check
- node --check pc-bridge/setup-web/app.js
- git diff --check
- GET http://127.0.0.1:8787/index.html
- GET http://127.0.0.1:8787/app.js
- POST http://127.0.0.1:8787/api/firebase-setup-qr