### PR TITLE
release APK署名手順を整備

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,9 +1,25 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+val hasReleaseKeystore = keystorePropertiesFile.exists()
+if (hasReleaseKeystore) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+}
+
+if (!hasReleaseKeystore && gradle.startParameter.taskNames.any { it.contains("Release", ignoreCase = true) }) {
+    throw GradleException(
+        "Missing app/android/key.properties. Create it from key.properties.example before building a distributable release APK.",
+    )
 }
 
 android {
@@ -31,11 +47,22 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        if (hasReleaseKeystore) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            if (hasReleaseKeystore) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 }

--- a/app/android/key.properties.example
+++ b/app/android/key.properties.example
@@ -1,0 +1,4 @@
+storePassword=change-me
+keyPassword=change-me
+keyAlias=upload
+storeFile=D:\\secure\\codex-remote-upload-keystore.jks

--- a/docs/distribution-prep.md
+++ b/docs/distribution-prep.md
@@ -147,3 +147,5 @@ QRに含めてはいけないもの:
 - #129 配布前セキュリティレビューを実施する
 
 配布前セキュリティレビューの結果は [配布前セキュリティレビュー](security-review-distribution.md) に記録する。
+
+release APK作成手順と署名方針は [release APK作成手順](release-apk.md) に記録する。

--- a/docs/release-apk.md
+++ b/docs/release-apk.md
@@ -1,0 +1,150 @@
+# release APK作成手順
+
+この文書は、Codex Remote Androidを自分以外の利用者へ配布するためのAPK作成手順をまとめる。
+
+## 方針
+
+- 配布APKのpackage名は `com.sunmax.remotecodex` に固定する。
+- debug署名APKは配布用途に使わない。
+- release APKはローカルPC上の署名鍵で署名する。
+- 署名鍵、key password、`key.properties` はGitに含めない。
+- Google Play公開は現時点の対象外とし、まずは内部配布用APKを対象にする。
+
+## version更新
+
+Flutterのversionは [app/pubspec.yaml](../app/pubspec.yaml) の `version` で管理する。
+
+例:
+
+```yaml
+version: 1.0.1+2
+```
+
+- `1.0.1`: 利用者向けのversionName
+- `2`: AndroidのversionCode
+
+配布前には、前回配布版より `versionCode` を必ず増やす。
+
+## 署名鍵を作成する
+
+署名鍵はGit管理外の安全な場所に保存する。例では `D:\secure` を使う。
+
+```powershell
+New-Item -ItemType Directory -Force -Path D:\secure
+keytool -genkeypair `
+  -v `
+  -keystore D:\secure\codex-remote-upload-keystore.jks `
+  -storetype JKS `
+  -keyalg RSA `
+  -keysize 2048 `
+  -validity 10000 `
+  -alias upload
+```
+
+入力したstore password、key password、alias、keystoreの場所は再配布や更新に必要になる。紛失すると同じ署名の更新APKを作れなくなるため、Git以外の安全な方法で保管する。
+
+## key.propertiesを作成する
+
+[app/android/key.properties.example](../app/android/key.properties.example) をコピーして `app/android/key.properties` を作成する。
+
+```powershell
+Copy-Item app\android\key.properties.example app\android\key.properties
+```
+
+内容を自分の署名鍵に合わせて編集する。
+
+```properties
+storePassword=<store password>
+keyPassword=<key password>
+keyAlias=upload
+storeFile=D:\\secure\\codex-remote-upload-keystore.jks
+```
+
+`app/android/key.properties` は `.gitignore` で除外されている。コミットしない。
+
+## release APKをビルドする
+
+事前に `app/android/app/google-services.json` が存在し、Firebase Androidアプリのpackage名が `com.sunmax.remotecodex` で登録されていることを確認する。
+
+```powershell
+cd app
+flutter clean
+flutter pub get
+flutter build apk --release
+```
+
+出力先:
+
+```text
+app/build/app/outputs/flutter-apk/app-release.apk
+```
+
+`key.properties` がない状態では、releaseビルドは失敗する。配布用APKを作成する前に必ず署名鍵を用意する。
+
+## APKを確認する
+
+インストール前に、APKの存在と更新時刻を確認する。
+
+```powershell
+Get-Item app\build\app\outputs\flutter-apk\app-release.apk |
+  Select-Object FullName,Length,LastWriteTime
+```
+
+署名状態を確認する。
+
+```powershell
+$apksigner = Get-ChildItem "$env:LOCALAPPDATA\Android\Sdk\build-tools" -Recurse -Filter apksigner.bat |
+  Sort-Object FullName -Descending |
+  Select-Object -First 1 -ExpandProperty FullName
+& $apksigner verify --verbose app\build\app\outputs\flutter-apk\app-release.apk
+```
+
+`Verified using v2 scheme (APK Signature Scheme v2): true` のように署名検証が成功することを確認する。
+
+実機へインストールして、最低限次を確認する。
+
+```powershell
+adb install -r app\build\app\outputs\flutter-apk\app-release.apk
+```
+
+確認項目:
+
+- アプリ名が `RemoteCodex` と表示される。
+- Firebase setup QRを読み取れる。
+- 匿名認証が成功する。
+- PCブリッジのheartbeatが表示される。
+- セッション作成から完了または失敗表示まで確認できる。
+- 完了通知が届く。
+
+## リリースノート項目
+
+APK配布時には次を記載する。
+
+- versionName / versionCode
+- 配布日
+- APKファイル名
+- 対象package名: `com.sunmax.remotecodex`
+- 主な変更点
+- 既知の制限
+- セットアップに必要なもの
+  - Firebaseプロジェクト
+  - PCブリッジ
+  - Node.js / npm
+  - Codex CLI
+- 秘密情報の注意
+  - service account JSONを共有しない
+  - `key.properties` と署名鍵を共有しない
+  - GitHub Issueやログにtokenを貼らない
+
+## 判断が必要な項目
+
+次は配布者の判断が必要。
+
+- 署名鍵の正式な保管場所
+- APKを配布する場所
+  - GitHub Release
+  - 個別共有
+  - 社内/限定配布ストレージ
+- 配布対象端末とAndroid versionの範囲
+- 初回配布version
+- Google Play公開を将来対象にするか

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -4,7 +4,7 @@
 
 Xperia 1 IIIにインストールできるAndroidアプリをMVPのRelease対象とする。
 
-最初のReleaseはdebug署名または内部配布用署名のAPKでよい。Google Play公開はMVP範囲外とする。
+最初のReleaseは内部配布用署名のAPKを対象とする。debug署名APKは配布用途に使わない。Google Play公開はMVP範囲外とする。
 
 ## Release準備チェックリスト
 
@@ -40,3 +40,7 @@ Releaseは次を満たした時点で完了とする。
 - セッションpayloadを暗号化する。
 - 複数PCブリッジ登録に対応する。
 - ARBベースの翻訳管理または専門翻訳ワークフローを導入する。
+
+## release APK作成手順
+
+release APKの作成手順、署名鍵の扱い、version更新、リリースノート項目は [release APK作成手順](release-apk.md) を参照する。

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -94,7 +94,7 @@ firstInstallTime=2026-04-27 01:39:19
 
 ## 既知制限
 
-- Release buildは現時点でdebug signing configを使っている。Google Play公開用の正式署名ではない。
+- Release 1.0.0時点ではdebug signing configを使っていた。今後の配布用途では [release APK作成手順](../release-apk.md) に従い、内部配布用署名鍵で署名する。
 - Google Play公開はMVP範囲外。
 - `npm audit` のlow/moderate警告は #97 で既知制限として評価済み。high/criticalは検出されていない。
 - ワイヤレスデバッグのdevice idとポートは変わる。インストール前に `flutter devices` または `adb devices -l` で確認する。


### PR DESCRIPTION
Closes #124

## Summary
- release APK作成手順を追加し、署名鍵作成、key.properties、version更新、apksigner確認、リリースノート項目を整理
- key.properties.example を追加
- release buildがkey.propertiesなしで進まないようGradle設定を変更
- release planと既存1.0.0記録を配布用署名方針に合わせて更新

## Verification
- flutter analyze
- git diff --check
- flutter build apk --release が key.properties 未作成時に明示エラーで停止することを確認
- 変更前に生成されたAPKを apksigner verify し、署名検証に失敗することを確認して対策対象を確認