### PR TITLE
PCブリッジ配布パッケージ手順を追加

### DIFF
--- a/docs/distribution-prep.md
+++ b/docs/distribution-prep.md
@@ -149,3 +149,5 @@ QRに含めてはいけないもの:
 配布前セキュリティレビューの結果は [配布前セキュリティレビュー](security-review-distribution.md) に記録する。
 
 release APK作成手順と署名方針は [release APK作成手順](release-apk.md) に記録する。
+
+PCブリッジ配布パッケージの作成・展開・起動手順は [PCブリッジ配布パッケージ](pc-bridge-distribution.md) に記録する。

--- a/docs/pc-bridge-distribution.md
+++ b/docs/pc-bridge-distribution.md
@@ -1,0 +1,194 @@
+# PCブリッジ配布パッケージ
+
+この文書は、Codex Remote AndroidのPCブリッジを利用者へ配布するための手順をまとめる。
+
+## 暫定方針
+
+現時点では、PCブリッジはzipパッケージとして配布する。
+
+- exe化はまだ行わない。
+- 利用者PCで `npm.cmd install` を実行する。
+- Node.js 22以上を前提にする。
+- `config.local.json` と service account JSON は利用者PCだけで作成する。
+- `node_modules`、ログ、ローカル設定、service account JSONはzipに含めない。
+
+exe化は、配布経路、署名、アップデート方式、Windows SmartScreen対策を決めてから別Issueで扱う。
+
+## 配布パッケージを作成する
+
+リポジトリルートで次を実行する。
+
+```powershell
+cd pc-bridge
+npm.cmd install
+npm.cmd run package:dist
+```
+
+出力先:
+
+```text
+pc-bridge\.local\distribution\codex-remote-pc-bridge.zip
+```
+
+zipには次を含める。
+
+- `README.md`
+- `config.example.json`
+- `package.json`
+- `package-lock.json`
+- `tsconfig.json`
+- `src/`
+- `scripts/`
+- `setup-web/`
+- `dist/`
+- `docs/pc-bridge-distribution.md`
+- `docs/distribution-prep.md`
+
+zipには次を含めない。
+
+- `config.local.json`
+- `node_modules/`
+- `.local/`
+- `logs/`
+- service account JSON
+- Firebase debug log
+- Codex / GitHub / OpenAI など外部サービスのtoken
+
+## 利用者PCで展開する
+
+例:
+
+```powershell
+New-Item -ItemType Directory -Force -Path D:\Tools\CodexRemote
+Expand-Archive .\codex-remote-pc-bridge.zip -DestinationPath D:\Tools\CodexRemote -Force
+Set-Location D:\Tools\CodexRemote\codex-remote-pc-bridge
+```
+
+依存関係をインストールする。
+
+```powershell
+npm.cmd install
+npm.cmd run build
+```
+
+## config.local.jsonを作成する
+
+```powershell
+Copy-Item config.example.json config.local.json
+```
+
+主な設定:
+
+- `relayMode`: 本番利用では `firestore`
+- `firebaseProjectId`: 利用者自身のFirebase project ID
+- `serviceAccountPath`: PCローカルのservice account JSONパス
+- `pcBridgeId`: 通常は `home-main-pc`
+- `displayName`: Androidアプリに表示するPC名
+- `workspaceName`: 作業場所の表示名
+- `workspacePath`: Codex CLIを実行する作業ディレクトリ
+- `codexMode`: Codex CLIを使う場合は `cli`
+- `codexCommandPath`: 例 `codex.cmd`
+- `codexModel`: 既定モデル
+- `codexBypassSandbox`: 既定は `false`
+
+`config.local.json` はGit、Issue、チャット、スクリーンショットに含めない。
+
+## セットアップWeb UIを起動する
+
+AndroidアプリへFirebase client configを入力するため、PCセットアップWeb UIを使う。
+
+```powershell
+npm.cmd run setup:web
+```
+
+ブラウザで開く。
+
+```text
+http://127.0.0.1:8787
+```
+
+UIで `google-services.json` を読み込み、QRを生成する。service account JSONはQRへ含めない。
+
+## PCブリッジを起動する
+
+手動起動:
+
+```powershell
+npm.cmd run start:watch
+```
+
+バックグラウンド起動:
+
+```powershell
+.\scripts\start-watch-background.bat
+```
+
+Windowsログオン時に自動起動するタスク登録:
+
+```powershell
+.\scripts\register-watch-task.bat
+schtasks /Run /TN "CodexRemotePcBridge"
+```
+
+## 起動確認
+
+プロセス確認:
+
+```powershell
+Get-CimInstance Win32_Process |
+  Where-Object { $_.CommandLine -match 'dist[\\/]+src[\\/]+watch.js|start:watch|run-watch.bat' } |
+  Select-Object ProcessId,Name,CommandLine
+```
+
+ログ確認:
+
+```powershell
+Get-ChildItem .\logs -Filter 'pc-bridge-watch-*.log' |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1 |
+  ForEach-Object { Get-Content $_.FullName -Tail 40 }
+```
+
+Androidアプリ側では、PC接続情報の最終heartbeat時刻が更新されることを確認する。
+
+## 停止する
+
+手動起動中は `Ctrl+C` で停止する。
+
+バックグラウンド起動の場合:
+
+```powershell
+Get-CimInstance Win32_Process |
+  Where-Object { $_.CommandLine -match 'dist[\\/]+src[\\/]+watch.js|start:watch|run-watch.bat' } |
+  Select-Object ProcessId,Name,CommandLine
+Stop-Process -Id <ProcessId>
+```
+
+タスクスケジューラ登録を削除する場合:
+
+```powershell
+schtasks /Delete /TN "CodexRemotePcBridge" /F
+```
+
+## 配布者向けチェックリスト
+
+- [ ] zip作成前に `npm.cmd run check` が通っている。
+- [ ] `npm.cmd run package:dist` が成功している。
+- [ ] zipに `config.local.json` が含まれていない。
+- [ ] zipに `node_modules/` が含まれていない。
+- [ ] zipに `logs/` が含まれていない。
+- [ ] zipにservice account JSONが含まれていない。
+- [ ] 利用者向けにNode.js 22以上が必要であることを案内している。
+- [ ] 利用者向けにCodex CLIが必要であることを案内している。
+
+## 判断が必要な項目
+
+次は配布者の判断が必要。
+
+- zipをどこで配布するか
+  - GitHub Release
+  - 個別共有
+  - 限定公開ストレージ
+- 将来的にexe化するか
+- PCブリッジの自動アップデートを用意するか
+- 利用者ごとに既定 `pcBridgeId` を変えるか

--- a/pc-bridge/package.json
+++ b/pc-bridge/package.json
@@ -11,7 +11,8 @@
     "check": "tsc --noEmit",
     "validate:local": "tsc && node dist/scripts/validate-local-relay.js",
     "qr:firebase": "tsc && node dist/scripts/generate-firebase-setup-qr.js",
-    "setup:web": "tsc && node dist/scripts/setup-web.js"
+    "setup:web": "tsc && node dist/scripts/setup-web.js",
+    "package:dist": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-distribution.ps1"
   },
   "dependencies": {
     "firebase-admin": "^13.0.0",

--- a/pc-bridge/scripts/package-distribution.ps1
+++ b/pc-bridge/scripts/package-distribution.ps1
@@ -1,0 +1,57 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$bridgeRoot = Resolve-Path (Join-Path $scriptRoot '..')
+$repoRoot = Resolve-Path (Join-Path $bridgeRoot '..')
+$stagingRoot = Join-Path $bridgeRoot '.local\distribution'
+$packageRoot = Join-Path $stagingRoot 'codex-remote-pc-bridge'
+$zipPath = Join-Path $stagingRoot 'codex-remote-pc-bridge.zip'
+
+Push-Location $bridgeRoot
+try {
+  & npm.cmd run build
+} finally {
+  Pop-Location
+}
+
+if (Test-Path $packageRoot) {
+  Remove-Item -LiteralPath $packageRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $packageRoot | Out-Null
+
+$items = @(
+  'README.md',
+  'config.example.json',
+  'package.json',
+  'package-lock.json',
+  'tsconfig.json',
+  'src',
+  'scripts',
+  'setup-web',
+  'dist'
+)
+
+foreach ($item in $items) {
+  $source = Join-Path $bridgeRoot $item
+  $destination = Join-Path $packageRoot $item
+  Copy-Item -LiteralPath $source -Destination $destination -Recurse -Force
+}
+
+$docsRoot = Join-Path $packageRoot 'docs'
+New-Item -ItemType Directory -Force -Path $docsRoot | Out-Null
+Copy-Item -LiteralPath (Join-Path $repoRoot 'docs\pc-bridge-distribution.md') -Destination $docsRoot -Force
+Copy-Item -LiteralPath (Join-Path $repoRoot 'docs\distribution-prep.md') -Destination $docsRoot -Force
+
+Remove-Item -LiteralPath (Join-Path $packageRoot 'config.local.json') -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath (Join-Path $packageRoot 'node_modules') -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath (Join-Path $packageRoot 'logs') -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath (Join-Path $packageRoot '.local') -Recurse -Force -ErrorAction SilentlyContinue
+
+if (Test-Path $zipPath) {
+  Remove-Item -LiteralPath $zipPath -Force
+}
+Compress-Archive -Path $packageRoot -DestinationPath $zipPath -Force
+
+Write-Output "PC bridge distribution package written:"
+Write-Output $zipPath


### PR DESCRIPTION
Closes #126

## Summary
- PCブリッジzip配布方針と利用者向け展開・設定・起動・停止手順を追加
- package:dist npm scriptを追加
- scripts/package-distribution.ps1 でzip配布物を生成
- 配布準備ドキュメントからPCブリッジ配布手順へリンク

## Verification
- npm.cmd run check in pc-bridge
- npm.cmd run package:dist
- git diff --check
- 生成zipに config.local.json / node_modules / logs / serviceAccount / firebase-debug / .env / google-services が含まれないことを確認