### PR TITLE
配布利用者向けトラブルシュートを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ firebase deploy --only functions
 - [Androidアプリ手順](app/README.md)
 - [配布準備](docs/distribution-prep.md)
 - [利用者向けクイックスタート](docs/user-quickstart.md)
+- [配布利用者向けトラブルシュート](docs/troubleshooting-distribution.md)
 
 ## ライセンス
 

--- a/docs/distribution-prep.md
+++ b/docs/distribution-prep.md
@@ -153,3 +153,5 @@ release APK作成手順と署名方針は [release APK作成手順](release-apk.
 PCブリッジ配布パッケージの作成・展開・起動手順は [PCブリッジ配布パッケージ](pc-bridge-distribution.md) に記録する。
 
 利用者が初回セッション成功まで進めるための最短手順は [利用者向けクイックスタート](user-quickstart.md) に記録する。
+
+配布利用者向けの代表的な失敗と切り分け手順は [配布利用者向けトラブルシュート](troubleshooting-distribution.md) に記録する。

--- a/docs/troubleshooting-distribution.md
+++ b/docs/troubleshooting-distribution.md
@@ -1,0 +1,242 @@
+# 配布利用者向けトラブルシュート
+
+この文書は、配布APKとPCブリッジzipを使う利用者向けの切り分け手順である。
+
+## 共有してはいけない情報
+
+問い合わせやIssue投稿時に、次は貼らない。
+
+- service account JSON
+- private key
+- `config.local.json`
+- Firebase debug log全文
+- PCブリッジログ全文
+- FCM token
+- Codex / GitHub / OpenAI など外部サービスのtoken
+- 署名鍵
+- `key.properties`
+
+ログを共有する場合は、project ID、UID、メールアドレス、token、ローカルパスをマスクする。
+
+## まず確認すること
+
+1. Android package名が `com.sunmax.remotecodex` でFirebaseに登録されている。
+2. AndroidアプリでFirebase setup QRを保存している。
+3. Firebase AuthenticationのAnonymous sign-inが有効である。
+4. Firestore Databaseが作成済みである。
+5. Firestore Rules / Indexesがデプロイ済みである。
+6. PCブリッジの `config.local.json` で `relayMode` が `firestore` である。
+7. `serviceAccountPath` のJSONファイルがPC上に存在する。
+8. PCブリッジが起動している。
+9. Codex CLIがPC上で実行できる。
+
+## QRが読み取れない
+
+確認項目:
+
+- PCセットアップWeb UIを開き直す。
+- `google-services.json` を再度読み込む。
+- QRを画面に大きく表示する。
+- スマホのカメラ権限を許可する。
+- Androidアプリの `Scan setup QR` から読み取っているか確認する。
+
+それでも読めない場合:
+
+- `google-services.json` が対象Firebaseプロジェクトのものか確認する。
+- Firebase Androidアプリのpackage名が `com.sunmax.remotecodex` か確認する。
+- ブラウザのズームやディスプレイ拡大率を変更して再生成する。
+
+## QR保存後にFirebase接続できない
+
+確認項目:
+
+- `projectId` が利用者自身のFirebase project IDになっている。
+- `apiKey`、`appId`、`messagingSenderId` が空ではない。
+- Android端末がインターネットへ接続できる。
+- Firebase AuthenticationでAnonymousが有効になっている。
+- Firestore Databaseが作成済みである。
+
+確認方法:
+
+- Androidアプリの接続設定画面で保存済みproject IDを確認する。
+- Firebase ConsoleのAuthenticationで匿名ユーザーが作成されているか確認する。
+- Firestoreに `users/{uid}` が作成されているか確認する。
+
+## PC接続情報が更新されない
+
+症状:
+
+- AndroidアプリのPC接続情報でheartbeatが古い。
+- `Check PC now` に反応しない。
+
+PC側確認:
+
+```powershell
+Get-CimInstance Win32_Process |
+  Where-Object { $_.CommandLine -match 'dist[\\/]+src[\\/]+watch.js|start:watch|run-watch.bat' } |
+  Select-Object ProcessId,Name,CommandLine
+```
+
+ログ確認:
+
+```powershell
+Get-ChildItem .\logs -Filter 'pc-bridge-watch-*.log' |
+  Sort-Object LastWriteTime -Descending |
+  Select-Object -First 1 |
+  ForEach-Object { Get-Content $_.FullName -Tail 80 }
+```
+
+設定確認:
+
+- `relayMode` が `firestore`
+- `firebaseProjectId` が正しい
+- `serviceAccountPath` が存在する
+- service account JSONが対象Firebaseプロジェクトのもの
+- `pcBridgeId` がAndroidアプリ側の対象PCと一致する
+
+## セッションがqueuedのまま進まない
+
+原因候補:
+
+- PCブリッジが起動していない。
+- PCブリッジが別Firebaseプロジェクトを見ている。
+- `pcBridgeId` が一致していない。
+- Firestore Rules / Indexesが未デプロイ。
+- service account JSONが無効。
+
+確認項目:
+
+1. PCブリッジログに `No queued command found` または `Processed command` が出ているか確認する。
+2. Firestoreで `users/{uid}/sessions/{sessionId}/commands/{commandId}` の `status` を確認する。
+3. commandの `targetPcBridgeId` と `config.local.json` の `pcBridgeId` を比較する。
+4. `firebaseProjectId` とAndroidアプリのproject IDが一致しているか確認する。
+
+## runningのまま終わらない
+
+原因候補:
+
+- Codex CLIが処理中。
+- Codex CLIが入力待ちになっている。
+- `codexTimeoutSeconds` が長い。
+- PCブリッジプロセスが途中で落ちた。
+
+確認項目:
+
+- PCブリッジログを確認する。
+- Codex CLIをPC上で直接実行できるか確認する。
+- `codexCommandPath` が正しいか確認する。
+- `workspacePath` が存在するか確認する。
+- `codexTimeoutSeconds` を確認する。
+
+## Codex CLIが見つからない
+
+PC上で確認する。
+
+```powershell
+codex.cmd --version
+codex.cmd exec --help
+```
+
+失敗する場合:
+
+- Codex CLIをインストールする。
+- `codexCommandPath` に絶対パスまたは `codex.cmd` を設定する。
+- タスクスケジューラ起動時にPATHが足りない場合は絶対パスを使う。
+
+## failedになる
+
+確認項目:
+
+- Androidアプリのエラー表示を確認する。
+- Firestoreのcommand documentの `errorText` を確認する。
+- PCブリッジログを確認する。
+- `workspacePath` が存在し、Codex CLIがアクセスできるか確認する。
+- モデル名がCodex CLIで利用可能か確認する。
+- `codexBypassSandbox` を有効にする必要がある操作か確認する。
+
+注意:
+
+`errorText` にはredactionが入るが、ログやFirestoreを共有する前には必ず秘密情報が含まれていないか確認する。
+
+## 通知が届かない
+
+確認項目:
+
+- Androidで通知権限を許可している。
+- Android端末がインターネットへ接続できる。
+- Firebase Cloud Messagingが利用可能。
+- `firebase deploy --only functions` が成功している。
+- Firestoreの `users/{uid}/devices/android-app` にFCM tokenが保存されている。
+- command documentに `notificationSentAt`、`notificationSuccessCount`、`notificationFailureCount` が記録されている。
+
+Functionsログを確認する。
+
+```powershell
+cd firebase
+firebase functions:log
+```
+
+## PCブリッジが起動しない
+
+確認項目:
+
+- Node.js 22以上が入っている。
+- `npm.cmd install` が完了している。
+- `npm.cmd run build` が成功する。
+- `config.local.json` が存在する。
+- JSON構文が正しい。
+
+チェック:
+
+```powershell
+node --version
+npm.cmd --version
+npm.cmd run check
+npm.cmd run build
+```
+
+## service account JSONのエラー
+
+確認項目:
+
+- `serviceAccountPath` のパスが正しい。
+- JSONファイルが削除または移動されていない。
+- 対象Firebase/GCPプロジェクトのservice accountである。
+- private keyを含むJSON keyである。
+- JSON全文をIssueやチャットに貼っていない。
+
+## Firestore Rules / Indexesのエラー
+
+再デプロイする。
+
+```powershell
+cd firebase
+firebase use
+firebase deploy --only firestore:rules,firestore:indexes
+```
+
+Firestoreのindex作成直後は反映に時間がかかることがある。
+
+## 問い合わせ時に共有してよい情報
+
+共有してよいもの:
+
+- アプリversion
+- Android機種とAndroid version
+- PCのOS
+- Node.js version
+- Codex CLI version
+- Firebase project IDの一部をマスクしたもの
+- 画面のエラーメッセージ
+- マスク済みログの該当部分
+- `pcBridgeId`
+- command status
+
+共有前にマスクするもの:
+
+- UID
+- ローカルパス
+- project ID
+- メールアドレス
+- token
+- service account情報


### PR DESCRIPTION
Closes #128

## Summary
- 配布利用者向けトラブルシュート集を追加
- QR、Firebase接続、PC heartbeat、queued/running、Codex CLI、通知、service account、Rules/Indexesの切り分けを整理
- 問い合わせ時に共有してはいけない情報と共有してよい情報を明記
- READMEと配布準備ドキュメントからリンク追加

## Verification
- git diff --check
- rgで主要症状、固定package名、秘密情報注意、com.sample参照なしを確認