### PR TITLE
Prepare Android release 1.0.2

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.2+2
 
 environment:
   sdk: ^3.11.5

--- a/docs/releases/1.0.2.md
+++ b/docs/releases/1.0.2.md
@@ -1,0 +1,66 @@
+# Release 1.0.2 evidence
+
+Date: 2026-04-27
+
+Target issue: #142
+
+## Release target
+
+| Item | Value |
+| --- | --- |
+| app version | `1.0.2` |
+| build number / versionCode | `2` |
+| package name | `com.sunmax.remotecodex` |
+| minSdk | `24` |
+| targetSdk | `36` |
+| APK | `app/build/app/outputs/flutter-apk/app-release.apk` |
+| APK size | `70,063,705 bytes` |
+| APK SHA-256 | `7678F3626CA9BB024ABB7667475F3341CEAC1EB09A286C533A11A0515DE34D4F` |
+
+## Build
+
+```powershell
+Set-Location app
+flutter build apk --release
+```
+
+Result: success.
+
+Flutter produced:
+
+```text
+build\app\outputs\flutter-apk\app-release.apk
+```
+
+## Verification
+
+APK metadata:
+
+```text
+package: name='com.sunmax.remotecodex' versionCode='2' versionName='1.0.2'
+sdkVersion:'24'
+targetSdkVersion:'36'
+```
+
+Signature verification:
+
+```powershell
+apksigner verify --print-certs app\build\app\outputs\flutter-apk\app-release.apk
+```
+
+Result: success. The APK is signed with the internal distribution certificate.
+
+## Local signing material
+
+The release build used local signing material only.
+
+- `app/android/key.properties`: Git-ignored local file.
+- upload keystore: stored outside the repository.
+
+Do not commit or share `key.properties`, keystore files, store passwords, or key passwords.
+
+## Notes
+
+- This build is intended for internal GitHub Release distribution.
+- Google Play distribution remains out of scope for this release.
+- The APK artifact itself remains Git-ignored and is not committed to the repository.


### PR DESCRIPTION
## Summary
- Bump Android app version to `1.0.2+2`
- Build a signed release APK locally
- Add release evidence for the generated APK

## Validation
- `flutter build apk --release`
- `apksigner verify --print-certs app\build\app\outputs\flutter-apk\app-release.apk`
- `aapt dump badging app\build\app\outputs\flutter-apk\app-release.apk`
- `git diff --check`

Closes #142