### PR TITLE
Record PC bridge distribution package

### DIFF
--- a/docs/releases/1.0.2.md
+++ b/docs/releases/1.0.2.md
@@ -64,3 +64,34 @@ Do not commit or share `key.properties`, keystore files, store passwords, or key
 - This build is intended for internal GitHub Release distribution.
 - Google Play distribution remains out of scope for this release.
 - The APK artifact itself remains Git-ignored and is not committed to the repository.
+
+## PC Bridge Package
+
+Target issue: #143
+
+| Item | Value |
+| --- | --- |
+| zip | `pc-bridge/.local/distribution/codex-remote-pc-bridge.zip` |
+| zip size | `84,230 bytes` |
+| zip SHA-256 | `93DF83CDE78827EFCA916AA4F826EA814F766830ECAE77BB1A397413505705A4` |
+| zip entries | `41` |
+
+Validation:
+
+```powershell
+Set-Location pc-bridge
+npm.cmd run check
+npm.cmd run package:dist
+```
+
+Result: success.
+
+The zip content was inspected after generation. The following were not present:
+
+- `config.local.json`
+- `node_modules/`
+- `logs/`
+- service account JSON
+- Firebase debug log
+
+The package documentation continues to state that users need Node.js 22 or later and Codex CLI installed on the PC.


### PR DESCRIPTION
## Summary
- Build the PC bridge distribution zip locally
- Inspect the zip contents for local settings and secret files
- Record package evidence in the 1.0.2 release notes

## Validation
- `npm.cmd run check` in `pc-bridge`
- `npm.cmd run package:dist` in `pc-bridge`
- zip content inspection confirmed no `config.local.json`, `node_modules/`, `logs/`, service account JSON, or Firebase debug log
- `git diff --check`

Closes #143