### PR TITLE
Record final distribution security audit

### DIFF
--- a/docs/releases/1.0.2.md
+++ b/docs/releases/1.0.2.md
@@ -95,3 +95,58 @@ The zip content was inspected after generation. The following were not present:
 - Firebase debug log
 
 The package documentation continues to state that users need Node.js 22 or later and Codex CLI installed on the PC.
+
+## Final Security Audit
+
+Target issue: #144
+
+### Git And Local Artifact Boundaries
+
+Checked Git-tracked files for release-sensitive artifacts and secret markers.
+
+Tracked allowlist findings:
+
+- `app/android/key.properties.example`
+- masked service account screenshots under `docs/assets/firebase-setup-screenshots/masked/`
+
+Ignored local files confirmed:
+
+- `app/android/app/google-services.json`
+- `app/android/key.properties`
+- `app/build/`
+- `firebase/firebase-debug.log`
+- `pc-bridge/.local/`
+- `pc-bridge/config.local.json`
+- `pc-bridge/logs/`
+
+These files are not committed.
+
+### npm Audit
+
+```powershell
+Set-Location pc-bridge
+npm.cmd audit --audit-level=high
+
+Set-Location ..\firebase\functions
+npm.cmd audit --audit-level=high
+```
+
+Result: both commands exited successfully. No high or critical blocker was detected.
+
+Known low/moderate Firebase SDK transitive dependency warnings remain. `npm audit fix --force` still proposes a breaking downgrade path and is not used for this release.
+
+### QR Payload Boundary
+
+The Firebase setup QR payload was checked from the local `google-services.json`.
+
+Payload keys:
+
+```text
+apiKey, appId, messagingSenderId, projectId, schema, storageBucket
+```
+
+The payload did not include service account JSON, private keys, client email, or Admin SDK credentials.
+
+### Redaction Boundary
+
+The Android setup UI warns users not to paste service account JSON or Admin SDK credentials. The PC bridge and Firebase Functions still redact private key and credential-shaped values from process output and notification summaries before persisting or sending them.


### PR DESCRIPTION
## Summary
- Re-run final distribution security checks
- Confirm ignored local secret/artifact boundaries
- Re-run high-level npm audits for PC bridge and Firebase Functions
- Confirm Firebase setup QR payload excludes service account/Admin SDK fields
- Record results in the 1.0.2 release evidence

## Validation
- Git-tracked release-sensitive path scan
- `git status --short --ignored` for local secrets/artifacts
- `npm.cmd audit --audit-level=high` in `pc-bridge`
- `npm.cmd audit --audit-level=high` in `firebase/functions`
- QR payload key inspection from local `google-services.json`
- `git diff --check`

Closes #144