### PR TITLE
docs: record 1.0.2 release E2E smoke

### DIFF
--- a/docs/releases/1.0.2.md
+++ b/docs/releases/1.0.2.md
@@ -150,3 +150,50 @@ The payload did not include service account JSON, private keys, client email, or
 ### Redaction Boundary
 
 The Android setup UI warns users not to paste service account JSON or Admin SDK credentials. The PC bridge and Firebase Functions still redact private key and credential-shaped values from process output and notification summaries before persisting or sending them.
+
+## Release E2E Smoke
+
+Target issue: #145
+
+Date: 2026-04-27
+
+Device:
+
+```text
+SO 51B (wireless), Android 13 (API 33)
+```
+
+Installed APK metadata after release install:
+
+```text
+package: com.sunmax.remotecodex
+versionCode: 2
+versionName: 1.0.2
+minSdk: 24
+targetSdk: 36
+```
+
+Smoke flow:
+
+1. Installed the signed `1.0.2` release APK on the device.
+2. Launched the app and selected the bundled Firebase config for the existing verification project.
+3. Allowed notification permission.
+4. Confirmed the session list opened and showed the `home-main-pc` PC bridge.
+5. Created a new session from the Android app.
+6. Sent `CLI_FIRESTORE_OK` from the Android app.
+7. Ran the PC bridge once with `npm.cmd run start`.
+8. Confirmed the command reached `completed` in Firestore and on the Android app.
+
+Result:
+
+```text
+status: completed
+targetPcBridgeId: home-main-pc
+notificationSuccessCount: 1
+```
+
+Notes:
+
+- The previously installed `1.0.0` APK used a different signing key, so Android rejected an in-place update with `INSTALL_FAILED_UPDATE_INCOMPATIBLE`. The smoke test uninstalled the old app first, then installed the signed `1.0.2` APK.
+- The uninstall reset the app's local Firebase setup state. The smoke used the bundled Firebase config route for this verification build.
+- The command response was rendered in the Android session detail screen.


### PR DESCRIPTION
## Summary
- Record the 1.0.2 release E2E smoke against the existing verification Firebase project
- Capture signed APK install metadata, Android device, command completion, and notification success evidence
- Note the expected debug-to-release signing reinstall requirement

## Verification
- Installed signed 1.0.2 APK on SO 51B wireless device
- Android app connected with bundled Firebase config
- Sent `CLI_FIRESTORE_OK` from Android app
- Ran `npm.cmd run start` in `pc-bridge`
- Firestore command reached `completed` with `notificationSuccessCount: 1`
- Android session detail rendered the completed result

Closes #145