### PR TITLE
docs: prepare 1.0.2 GitHub Release

### DIFF
--- a/docs/releases/1.0.2.md
+++ b/docs/releases/1.0.2.md
@@ -197,3 +197,41 @@ Notes:
 - The previously installed `1.0.0` APK used a different signing key, so Android rejected an in-place update with `INSTALL_FAILED_UPDATE_INCOMPATIBLE`. The smoke test uninstalled the old app first, then installed the signed `1.0.2` APK.
 - The uninstall reset the app's local Firebase setup state. The smoke used the bundled Firebase config route for this verification build.
 - The command response was rendered in the Android session detail screen.
+
+## GitHub Release Distribution
+
+Target issue: #146
+
+Distribution channel: GitHub Release.
+
+Release tag:
+
+```text
+v1.0.2
+```
+
+Planned assets:
+
+| Asset | Source | SHA-256 |
+| --- | --- | --- |
+| `RemoteCodex-1.0.2.apk` | `app/build/app/outputs/flutter-apk/app-release.apk` | `7678F3626CA9BB024ABB7667475F3341CEAC1EB09A286C533A11A0515DE34D4F` |
+| `codex-remote-pc-bridge-1.0.2.zip` | `pc-bridge/.local/distribution/codex-remote-pc-bridge.zip` | `93DF83CDE78827EFCA916AA4F826EA814F766830ECAE77BB1A397413505705A4` |
+| `SHA256SUMS.txt` | generated during release packaging | includes the two hashes above |
+
+Release note requirements:
+
+- Android app version: `1.0.2+2`.
+- Android package: `com.sunmax.remotecodex`.
+- Android requirement: Android 7.0 / API 24 or later.
+- PC requirement: Windows PC with Node.js 22 or later and Codex CLI.
+- Users must create and manage their own Firebase project.
+- Users must not share service account JSON, `key.properties`, keystore files, store passwords, or key passwords.
+- The PC bridge zip intentionally excludes `config.local.json`, logs, `node_modules`, service account JSON, and Firebase debug logs.
+
+Known limitations:
+
+- Google Play distribution is out of scope for this release.
+- Each user must complete Firebase setup before first use.
+- Existing debug-signed installs cannot be updated in place to this signed release APK. Uninstall the old debug build first.
+- PC wake from power-off is not included in this release.
+- npm audit still reports known low/moderate Firebase SDK transitive dependency warnings, with no high or critical blocker detected.


### PR DESCRIPTION
## Summary
- Record GitHub Release as the 1.0.2 distribution channel
- Document planned release asset names and SHA-256 hashes
- Capture release note requirements, secret handling notes, and known limitations

## Verification
- Rechecked local release APK SHA-256
- Rechecked local PC bridge zip SHA-256
- Confirmed `v1.0.2` release does not already exist

Closes #146