### PR TITLE
PCブリッジのclaim/timeout/redaction自動テストを追加

### DIFF
--- a/docs/pc-bridge-tests.md
+++ b/docs/pc-bridge-tests.md
@@ -1,0 +1,22 @@
+# PCブリッジ自動テスト
+
+Issue #153 以降、PCブリッジにはNode.js標準の `node:test` による自動テストを含める。
+ローカルでの確認は次を標準とする。
+
+```powershell
+Set-Location pc-bridge
+npm.cmd run check
+npm.cmd run test
+npm.cmd run validate:local
+```
+
+`npm.cmd run test` は実Firebaseに接続せず、ローカルJSON relayまたはRepository test doubleで次を確認する。
+
+- queued commandのclaimと、異なる `targetPcBridgeId` の除外。
+- `claimExpiresAt` を過ぎたrunning commandの再claim。
+- 期限内running commandを重複claimしないこと。
+- Codex invoker成功時のcompleted遷移。
+- Codex invoker失敗時のfailed遷移。
+- progress/result/error textに含まれるprivate key、Firebase API key、GitHub tokenなどのredaction。
+
+Firestore relay、実Codex CLI、通知連携は環境依存のため、Release前smokeまたは対象Issueの検証手順で別途確認する。

--- a/pc-bridge/README.md
+++ b/pc-bridge/README.md
@@ -443,3 +443,21 @@ If the terminal QR is hard to scan, also write a PNG:
 ```powershell
 npm run qr:firebase -- --out .local\firebase-setup-qr.png
 ```
+
+## 自動テスト
+
+PCブリッジの退行検出には、TypeScript checkに加えてNode.js標準の `node:test` を使う。
+
+```powershell
+cd pc-bridge
+npm.cmd run check
+npm.cmd run test
+```
+
+`npm.cmd run test` は `tsc` で `tests/**/*.ts` もビルドした後、`dist/tests/**/*.test.js` を実行する。
+2026-04-27時点の対象は次の通り。
+
+- `LocalRelayRepository` のqueued claim、targetPcBridgeId不一致除外、期限切れrunning commandの再claim、期限内running commandの除外。
+- `processNextCommand` のcompleted/failed遷移、progress/result/error textの秘密情報redaction、claim対象なしの `none` 応答。
+
+実Firebaseを使う確認は `npm.cmd run validate:local` やFirestore relayの手動smokeと分ける。単体テストではローカルJSON relayまたはRepository test doubleを使い、service account JSONや利用者のFirebase projectには依存しない。詳細は `docs/pc-bridge-tests.md` に記録する。

--- a/pc-bridge/package.json
+++ b/pc-bridge/package.json
@@ -9,6 +9,7 @@
     "start": "tsc && node dist/src/index.js",
     "start:watch": "tsc && node dist/src/watch.js",
     "check": "tsc --noEmit",
+    "test": "tsc && node --test \"dist/tests/**/*.test.js\"",
     "validate:local": "tsc && node dist/scripts/validate-local-relay.js",
     "qr:firebase": "tsc && node dist/scripts/generate-firebase-setup-qr.js",
     "setup:web": "tsc && node dist/scripts/setup-web.js",

--- a/pc-bridge/src/lib/codexInvoker.ts
+++ b/pc-bridge/src/lib/codexInvoker.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { redactSensitiveText } from "./redaction.js";
 import type { BridgeConfig, CodexInvocation, CodexInvocationResult, CodexInvoker } from "./types.js";
 
 export function createCodexInvoker(_config: BridgeConfig): CodexInvoker {
@@ -376,18 +377,4 @@ function cliErrorText(result: RunCodexExecResult, fallback: string): string {
   }
 
   return `${fallback}\n\n${detail}`;
-}
-
-function redactSensitiveText(value: string): string {
-  return value
-    .replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "[REDACTED_PRIVATE_KEY]")
-    .replace(/("private_key"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_PRIVATE_KEY]$3")
-    .replace(/("client_secret"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_CLIENT_SECRET]$3")
-    .replace(/("refresh_token"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_REFRESH_TOKEN]$3")
-    .replace(/("access_token"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_ACCESS_TOKEN]$3")
-    .replace(/AIza[0-9A-Za-z_-]{20,}/g, "[REDACTED_FIREBASE_API_KEY]")
-    .replace(/ya29\.[0-9A-Za-z._-]+/g, "[REDACTED_GOOGLE_ACCESS_TOKEN]")
-    .replace(/github_pat_[0-9A-Za-z_]+/g, "[REDACTED_GITHUB_TOKEN]")
-    .replace(/ghp_[0-9A-Za-z_]{30,}/g, "[REDACTED_GITHUB_TOKEN]")
-    .replace(/xox[baprs]-[0-9A-Za-z-]+/g, "[REDACTED_SLACK_TOKEN]");
 }

--- a/pc-bridge/src/lib/processor.ts
+++ b/pc-bridge/src/lib/processor.ts
@@ -1,3 +1,4 @@
+import { redactSensitiveText } from "./redaction.js";
 import type { BridgeConfig, CodexInvoker, CommandRepository } from "./types.js";
 
 export type ProcessNextCommandInput = {
@@ -40,13 +41,13 @@ export async function processNextCommand(input: ProcessNextCommandInput): Promis
     command,
     workspacePath: input.config.workspacePath,
     onProgress: (progressText, progressAt) =>
-      input.repository.updateProgress(claim, progressText, progressAt, input.config.claimTtlSeconds),
+      input.repository.updateProgress(claim, redactSensitiveText(progressText), progressAt, input.config.claimTtlSeconds),
   });
 
   const completedAt = new Date();
 
   if (result.kind === "success") {
-    await input.repository.markCompleted(claim, result.resultText, completedAt);
+    await input.repository.markCompleted(claim, redactSensitiveText(result.resultText), completedAt);
     return {
       kind: "processed",
       commandId: command.commandId,
@@ -54,7 +55,7 @@ export async function processNextCommand(input: ProcessNextCommandInput): Promis
     };
   }
 
-  await input.repository.markFailed(claim, result.errorText, completedAt);
+  await input.repository.markFailed(claim, redactSensitiveText(result.errorText), completedAt);
   return {
     kind: "processed",
     commandId: command.commandId,

--- a/pc-bridge/src/lib/redaction.ts
+++ b/pc-bridge/src/lib/redaction.ts
@@ -1,0 +1,13 @@
+export function redactSensitiveText(value: string): string {
+  return value
+    .replace(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g, "[REDACTED_PRIVATE_KEY]")
+    .replace(/("private_key"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_PRIVATE_KEY]$3")
+    .replace(/("client_secret"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_CLIENT_SECRET]$3")
+    .replace(/("refresh_token"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_REFRESH_TOKEN]$3")
+    .replace(/("access_token"\s*:\s*")([^"]+)(")/g, "$1[REDACTED_ACCESS_TOKEN]$3")
+    .replace(/AIza[0-9A-Za-z_-]{20,}/g, "[REDACTED_FIREBASE_API_KEY]")
+    .replace(/ya29\.[0-9A-Za-z._-]+/g, "[REDACTED_GOOGLE_ACCESS_TOKEN]")
+    .replace(/github_pat_[0-9A-Za-z_]+/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/ghp_[0-9A-Za-z_]{30,}/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/xox[baprs]-[0-9A-Za-z-]+/g, "[REDACTED_SLACK_TOKEN]");
+}

--- a/pc-bridge/tests/localRelayRepository.test.ts
+++ b/pc-bridge/tests/localRelayRepository.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { LocalRelayRepository } from "../src/lib/localRelayRepository.js";
+
+test("claimNextQueuedCommand claims only matching queued commands", async () => {
+  const relayPath = await createRelayState({
+    commandA: {
+      text: "run A",
+      status: "queued",
+      targetPcBridgeId: "pc-a",
+      createdAt: "2026-04-27T00:00:00.000Z",
+    },
+    commandB: {
+      text: "run B",
+      status: "queued",
+      targetPcBridgeId: "pc-b",
+      createdAt: "2026-04-27T00:00:00.000Z",
+    },
+  });
+  const repository = new LocalRelayRepository(relayPath);
+  const now = new Date("2026-04-27T01:00:00.000Z");
+
+  const claimed = await repository.claimNextQueuedCommand("pc-a", now, 300);
+
+  assert.equal(claimed?.commandId, "commandA");
+  assert.equal(claimed?.status, "running");
+
+  const state = await readRelayState(relayPath);
+  const commandA = state.users.userA.sessions.session1.commands.commandA;
+  const commandB = state.users.userA.sessions.session1.commands.commandB;
+
+  assert.equal(commandA.status, "running");
+  assert.equal(commandA.claimedByPcBridgeId, "pc-a");
+  assert.equal(commandA.claimedAt, "2026-04-27T01:00:00.000Z");
+  assert.equal(commandA.claimExpiresAt, "2026-04-27T01:05:00.000Z");
+  assert.equal(commandB.status, "queued");
+});
+
+test("claimNextQueuedCommand reclaims expired running commands", async () => {
+  const relayPath = await createRelayState({
+    commandExpired: {
+      text: "retry me",
+      status: "running",
+      targetPcBridgeId: "pc-a",
+      createdAt: "2026-04-27T00:00:00.000Z",
+      claimedByPcBridgeId: "pc-a",
+      claimExpiresAt: "2026-04-27T00:59:59.000Z",
+    },
+  });
+  const repository = new LocalRelayRepository(relayPath);
+
+  const claimed = await repository.claimNextQueuedCommand("pc-a", new Date("2026-04-27T01:00:00.000Z"), 120);
+
+  assert.equal(claimed?.commandId, "commandExpired");
+  assert.equal(claimed?.claimExpiresAt, "2026-04-27T01:02:00.000Z");
+});
+
+test("claimNextQueuedCommand ignores active running commands", async () => {
+  const relayPath = await createRelayState({
+    commandActive: {
+      text: "already running",
+      status: "running",
+      targetPcBridgeId: "pc-a",
+      createdAt: "2026-04-27T00:00:00.000Z",
+      claimedByPcBridgeId: "pc-a",
+      claimExpiresAt: "2026-04-27T01:05:00.000Z",
+    },
+  });
+  const repository = new LocalRelayRepository(relayPath);
+
+  const claimed = await repository.claimNextQueuedCommand("pc-a", new Date("2026-04-27T01:00:00.000Z"), 120);
+
+  assert.equal(claimed, null);
+});
+
+async function createRelayState(commands: Record<string, Record<string, unknown>>): Promise<string> {
+  const tempRoot = await mkdtemp(join(tmpdir(), "codex-remote-bridge-test-"));
+  const relayPath = join(tempRoot, "relay-state.json");
+  const state = {
+    users: {
+      userA: {
+        sessions: {
+          session1: {
+            status: "queued",
+            targetPcBridgeId: "pc-a",
+            commands,
+          },
+        },
+      },
+    },
+  };
+
+  await writeFile(relayPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  return relayPath;
+}
+
+async function readRelayState(relayPath: string): Promise<{
+  users: {
+    userA: {
+      sessions: {
+        session1: {
+          commands: Record<string, Record<string, unknown>>;
+        };
+      };
+    };
+  };
+}> {
+  return JSON.parse(await readFile(relayPath, "utf8"));
+}

--- a/pc-bridge/tests/processor.test.ts
+++ b/pc-bridge/tests/processor.test.ts
@@ -1,0 +1,131 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeConfig } from "../src/lib/config.js";
+import { processNextCommand } from "../src/lib/processor.js";
+import type { CodexInvoker, CommandClaim, CommandRepository, RemoteCommand } from "../src/lib/types.js";
+
+test("processNextCommand completes claimed commands and redacts progress and result text", async () => {
+  const repository = new MemoryCommandRepository(makeCommand());
+  const invoker: CodexInvoker = {
+    async invoke(input) {
+      await input.onProgress?.(
+        'working with "private_key":"-----BEGIN PRIVATE KEY-----abc-----END PRIVATE KEY-----"',
+        new Date("2026-04-27T01:00:01.000Z"),
+      );
+      return {
+        kind: "success",
+        resultText: "done with AIza123456789012345678901234567890123456",
+      };
+    },
+  };
+
+  const result = await processNextCommand({
+    config: testConfig(),
+    repository,
+    invoker,
+    now: new Date("2026-04-27T01:00:00.000Z"),
+  });
+
+  assert.deepEqual(result, { kind: "processed", commandId: "command1", status: "completed" });
+  assert.equal(repository.completed?.resultText, "done with [REDACTED_FIREBASE_API_KEY]");
+  assert.equal(
+    repository.progress[0]?.progressText,
+    'working with "private_key":"[REDACTED_PRIVATE_KEY]"',
+  );
+});
+
+test("processNextCommand marks invoker failures as failed and redacts error text", async () => {
+  const repository = new MemoryCommandRepository(makeCommand());
+  const invoker: CodexInvoker = {
+    async invoke() {
+      return {
+        kind: "failure",
+        errorText: "failed with ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+      };
+    },
+  };
+
+  const result = await processNextCommand({
+    config: testConfig(),
+    repository,
+    invoker,
+    now: new Date("2026-04-27T01:00:00.000Z"),
+  });
+
+  assert.deepEqual(result, { kind: "processed", commandId: "command1", status: "failed" });
+  assert.equal(repository.failed?.errorText, "failed with [REDACTED_GITHUB_TOKEN]");
+});
+
+test("processNextCommand returns none when no command is claimable", async () => {
+  const repository = new MemoryCommandRepository(null);
+  const invoker: CodexInvoker = {
+    async invoke() {
+      throw new Error("invoker should not be called");
+    },
+  };
+
+  const result = await processNextCommand({
+    config: testConfig(),
+    repository,
+    invoker,
+    now: new Date("2026-04-27T01:00:00.000Z"),
+  });
+
+  assert.deepEqual(result, { kind: "none" });
+});
+
+function testConfig() {
+  return normalizeConfig({
+    pcBridgeId: "pc-a",
+    displayName: "PC A",
+    workspaceName: "test",
+    workspacePath: "D:\\test",
+    relayMode: "local",
+    localRelayPath: ".local\\relay-state.json",
+    claimTtlSeconds: 300,
+  });
+}
+
+function makeCommand(): RemoteCommand {
+  return {
+    userId: "userA",
+    sessionId: "session1",
+    commandId: "command1",
+    text: "hello",
+    status: "running",
+    targetPcBridgeId: "pc-a",
+    createdAt: "2026-04-27T00:00:00.000Z",
+  };
+}
+
+class MemoryCommandRepository implements CommandRepository {
+  progress: Array<{ progressText: string; claimTtlSeconds: number }> = [];
+  completed?: { resultText: string };
+  failed?: { errorText: string };
+
+  constructor(private readonly command: RemoteCommand | null) {}
+
+  async claimNextQueuedCommand(): Promise<RemoteCommand | null> {
+    return this.command;
+  }
+
+  async updateProgress(_claim: CommandClaim, progressText: string, _now: Date, claimTtlSeconds: number): Promise<void> {
+    this.progress.push({ progressText, claimTtlSeconds });
+  }
+
+  async markCompleted(_claim: CommandClaim, resultText: string): Promise<void> {
+    this.completed = { resultText };
+  }
+
+  async markFailed(_claim: CommandClaim, errorText: string): Promise<void> {
+    this.failed = { errorText };
+  }
+
+  async updateHeartbeat(): Promise<void> {}
+
+  async updateQueueCheck(): Promise<void> {}
+
+  async respondPendingHealthChecks(): Promise<number> {
+    return 0;
+  }
+}

--- a/pc-bridge/tsconfig.json
+++ b/pc-bridge/tsconfig.json
@@ -10,6 +10,6 @@
     "rootDir": ".",
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts", "scripts/**/*.ts"]
+  "include": ["src/**/*.ts", "scripts/**/*.ts", "tests/**/*.ts"]
 }
 


### PR DESCRIPTION
## 概要
- PCブリッジに Node.js 標準の node:test ベースの自動テストを追加
- LocalRelayRepository の claim / timeout / targetPcBridgeId 判定をテスト
- processNextCommand の completed / failed 遷移と progress/result/error text の redaction をテスト
- redaction 処理を共通関数化し、CLIログだけでなく処理経路全体で適用
- README と docs/pc-bridge-tests.md にテスト手順を記録

## 検証
- npm.cmd run check
- npm.cmd run test
- npm.cmd run validate:local
- git diff --check

Closes #153