### PR TITLE
秘密情報を避けた診断ログ収集手順を整備

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: 不具合報告
-about: アプリ、PCブリッジ、Firebase連携の不具合を報告する
+about: Androidアプリ、PCブリッジ、Firebase連携の不具合を報告する
 title: "[Bug] "
 labels: bug
 assignees: ""
@@ -8,7 +8,7 @@ assignees: ""
 
 ## 概要
 
-何が起きているかを簡潔に書いてください。
+何が起きているかを1-3文で書いてください。
 
 ## 再現手順
 
@@ -18,28 +18,41 @@ assignees: ""
 
 ## 期待する動作
 
-本来どう動いてほしいかを書いてください。
 
 ## 実際の動作
 
-実際に起きた動作、エラー表示、状態を書いてください。
 
 ## 環境
 
-- Android端末:
-- Androidバージョン:
-- アプリバージョンまたはcommit:
+- アプリversion / Release tag:
+- Android端末 / OS version:
 - PC OS:
-- PCブリッジ起動方法:
-- Firebase project:
-- ネットワーク: WiFi / 携帯電話回線
+- Node.js version:
+- PCブリッジversion:
+- Codex CLI version:
+- Firebase project ID: `xxxx-***`
+- PCブリッジ起動方法: foreground / background bat / Task Scheduler
 
-## ログ・スクリーンショット
+## 診断情報
 
-関連するログやスクリーンショットがあれば添付してください。
+`pc-bridge` で次を実行し、秘密情報がないことを確認してから貼ってください。
 
-秘密情報、token、service account JSON、個人情報、非公開コード全文は貼らないでください。
+```powershell
+npm.cmd run diagnose
+```
+
+```json
+ここにredaction済み診断JSONを貼る
+```
+
+## Firebase確認結果
+
+- Functions log時刻:
+- command status:
+- notificationSuccessCount:
+- notificationFailureCount:
+- notificationLastError:
 
 ## 補足
 
-その他、気づいたことがあれば書いてください。
+貼らないもの: service account JSON、private key、token、UID原文、API key原文、`config.local.json` 全文、非公開コード全文。

--- a/docs/diagnostics-runbook.md
+++ b/docs/diagnostics-runbook.md
@@ -1,0 +1,119 @@
+# 診断ログ収集Runbook
+
+このRunbookは、Firebase設定、PCブリッジ、Android端末、通知、Codex CLIのどこで失敗しているかを、秘密情報を共有せずに切り分けるための手順である。
+
+## 共有してはいけない情報
+
+GitHub Issue、チャット、スクリーンショット、ログ抜粋には次を貼らない。
+
+- `config.local.json` の全文
+- service account JSON、private key、client secret
+- `google-services.json` の全文
+- FCM token、access token、refresh token、GitHub token
+- Firebase Anonymous AuthのUID原文
+- Firebase API key原文
+- ローカルPCの絶対パス、非公開ワークスペース内容
+
+共有が必要な場合は、先頭数文字と末尾数文字だけを残すか、`remotecodex-***` のようにマスクする。
+
+## PCブリッジ診断
+
+PCブリッジの設定検証、Node.js version、Codex CLI検出、最新ログのredaction済み末尾は次で取得する。
+
+```powershell
+Set-Location pc-bridge
+npm.cmd run diagnose
+```
+
+出力はJSONで、次の方針で安全化している。
+
+- `config.local.json` の原文は出さない。
+- `workspacePath` と `serviceAccountPath` の原文は出さない。
+- `ownerUserId` と `firebaseProjectId` はマスクする。
+- 最新PCブリッジログは `private_key`、token、Firebase API keyなどをredactしてから末尾だけ出す。
+
+Issueへ貼る前に、出力全体を目視で確認する。
+
+## Android側で確認する項目
+
+スマホ実機操作ができる利用者が確認する。Codex作業だけでは実機状態を保証しない。
+
+- アプリversionまたはGitHub Release tag。
+- Android端末名、Android version。
+- Firebase setup画面で表示されるproject IDのマスク値。
+- 通知権限が許可されているか。
+- 対象セッションのstatus、command status、表示されている直近エラー。
+- 通知タップで対象セッションへ遷移するか。
+
+スクリーンショットを貼る場合は、UID、token、API key、個人情報、非公開プロンプトを隠す。
+
+## Firebase側で確認する項目
+
+利用者自身のFirebase projectで確認する。
+
+```powershell
+Set-Location firebase
+firebase functions:log --only notifyCommandCompletion --limit 20
+```
+
+Firestore Consoleでは、対象user配下の次を確認する。
+
+- `users/{uid}/sessions/{sessionId}.status`
+- `users/{uid}/sessions/{sessionId}/commands/{commandId}.status`
+- `notificationSentAt`
+- `notificationSuccessCount`
+- `notificationFailureCount`
+- `notificationLastError`
+
+UID、token、result全文、error全文はIssueへ貼らない。必要なら時刻、status、count、マスク済みIDだけ共有する。
+
+## Issue報告テンプレート
+
+```markdown
+## 概要
+
+何が起きているかを1-3文で書く。
+
+## 再現手順
+
+1.
+2.
+3.
+
+## 期待する動作
+
+
+## 実際の動作
+
+
+## 環境
+
+- アプリversion / Release tag:
+- Android端末 / OS version:
+- PC OS:
+- Node.js version:
+- PCブリッジversion:
+- Codex CLI version:
+- Firebase project ID: `xxxx-***`
+- PCブリッジ起動方法: foreground / background bat / Task Scheduler
+
+## 診断情報
+
+`pc-bridge` で `npm.cmd run diagnose` を実行し、秘密情報がないことを確認してから貼る。
+
+```json
+ここにredaction済み診断JSONを貼る
+```
+
+## Firebase確認結果
+
+- Functions log時刻:
+- command status:
+- notificationSuccessCount:
+- notificationFailureCount:
+- notificationLastError:
+
+## 補足
+
+貼らないもの: service account JSON、private key、token、UID原文、API key原文、config.local.json全文、非公開コード全文。
+```

--- a/pc-bridge/README.md
+++ b/pc-bridge/README.md
@@ -461,3 +461,14 @@ npm.cmd run test
 - `processNextCommand` のcompleted/failed遷移、progress/result/error textの秘密情報redaction、claim対象なしの `none` 応答。
 
 実Firebaseを使う確認は `npm.cmd run validate:local` やFirestore relayの手動smokeと分ける。単体テストではローカルJSON relayまたはRepository test doubleを使い、service account JSONや利用者のFirebase projectには依存しない。詳細は `docs/pc-bridge-tests.md` に記録する。
+
+## 診断情報の収集
+
+不具合報告用に、秘密情報を避けたPCブリッジ診断JSONを出力できる。
+
+```powershell
+cd pc-bridge
+npm.cmd run diagnose
+```
+
+出力には `config.local.json`、service account JSON、local path原文、token原文は含めない。Issueへ貼る前に目視確認し、詳細手順は `docs/diagnostics-runbook.md` を参照する。

--- a/pc-bridge/package.json
+++ b/pc-bridge/package.json
@@ -11,6 +11,7 @@
     "check": "tsc --noEmit",
     "test": "tsc && node --test \"dist/tests/**/*.test.js\"",
     "validate:local": "tsc && node dist/scripts/validate-local-relay.js",
+    "diagnose": "tsc && node dist/scripts/collect-diagnostics.js",
     "qr:firebase": "tsc && node dist/scripts/generate-firebase-setup-qr.js",
     "setup:web": "tsc && node dist/scripts/setup-web.js",
     "package:dist": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-distribution.ps1"

--- a/pc-bridge/scripts/collect-diagnostics.ts
+++ b/pc-bridge/scripts/collect-diagnostics.ts
@@ -1,0 +1,220 @@
+import { access, readFile, readdir, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { loadBridgeConfig } from "../src/lib/config.js";
+import { redactSensitiveText } from "../src/lib/redaction.js";
+
+type DiagnosticReport = {
+  generatedAt: string;
+  pcBridge: {
+    packageVersion: string;
+    nodeVersion: string;
+    platform: string;
+    arch: string;
+  };
+  config: {
+    path: string;
+    valid: boolean;
+    error?: string;
+    relayMode?: string;
+    codexMode?: string;
+    codexSandbox?: string;
+    pcBridgeId?: string;
+    ownerUserId?: string;
+    firebaseProjectId?: string;
+    serviceAccountConfigured?: boolean;
+    serviceAccountPathExists?: boolean;
+    workspaceConfigured?: boolean;
+    localRelayConfigured?: boolean;
+  };
+  codexCli: {
+    commandPath?: string;
+    detected: boolean;
+    version?: string;
+    error?: string;
+  };
+  logs: {
+    latestLogFile?: string;
+    latestLogUpdatedAt?: string;
+    redactedTail?: string;
+  };
+  notes: string[];
+};
+
+const configPath = process.env.CODEX_REMOTE_BRIDGE_CONFIG ?? "config.local.json";
+
+const report: DiagnosticReport = {
+  generatedAt: new Date().toISOString(),
+  pcBridge: {
+    packageVersion: await readPackageVersion(),
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+  },
+  config: {
+    path: maskPath(resolve(configPath)),
+    valid: false,
+  },
+  codexCli: {
+    detected: false,
+  },
+  logs: {},
+  notes: [
+    "Do not attach config.local.json, service account JSON, google-services.json, tokens, private keys, or unredacted logs.",
+    "Review this output before sharing it in a public GitHub Issue.",
+  ],
+};
+
+try {
+  const config = await loadBridgeConfig(configPath);
+  const serviceAccountPathExists = config.serviceAccountPath
+    ? await exists(config.serviceAccountPath)
+    : false;
+
+  report.config = {
+    ...report.config,
+    valid: true,
+    relayMode: config.relayMode,
+    codexMode: config.codexMode,
+    codexSandbox: config.codexSandbox,
+    pcBridgeId: maskId(config.pcBridgeId),
+    ownerUserId: maskId(config.ownerUserId),
+    firebaseProjectId: maskProjectId(config.firebaseProjectId),
+    serviceAccountConfigured: typeof config.serviceAccountPath === "string" && config.serviceAccountPath.length > 0,
+    serviceAccountPathExists,
+    workspaceConfigured: config.workspacePath.length > 0,
+    localRelayConfigured: config.localRelayPath.length > 0,
+  };
+
+  report.codexCli = await inspectCodexCli(config.codexCommandPath);
+} catch (error) {
+  report.config.error = error instanceof Error ? error.message : String(error);
+}
+
+report.logs = await readLatestLogTail();
+
+console.log(JSON.stringify(report, null, 2));
+
+async function readPackageVersion(): Promise<string> {
+  const packageText = await readFile("package.json", "utf8");
+  const packageJson = JSON.parse(packageText) as { version?: string };
+  return packageJson.version ?? "unknown";
+}
+
+async function inspectCodexCli(commandPath: string): Promise<DiagnosticReport["codexCli"]> {
+  const result = await runCommand(commandPath, ["--version"]);
+  return {
+    commandPath: maskPath(commandPath),
+    detected: result.exitCode === 0,
+    version: result.exitCode === 0 ? redactSensitiveText(result.stdout.trim()) : undefined,
+    error: result.exitCode === 0 ? undefined : redactSensitiveText((result.stderr || result.stdout).trim()),
+  };
+}
+
+function runCommand(commandPath: string, args: string[]): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolveRun) => {
+    const launch = process.platform === "win32" && /\.(cmd|bat)$/i.test(commandPath)
+      ? { command: "cmd.exe", args: ["/d", "/s", "/c", commandPath, ...args] }
+      : { command: commandPath, args };
+    let child;
+
+    try {
+      child = spawn(launch.command, launch.args, {
+        shell: false,
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      resolveRun({
+        exitCode: 1,
+        stdout: "",
+        stderr: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      resolveRun({ exitCode: 1, stdout, stderr: stderr + error.message });
+    });
+    child.on("close", (exitCode) => {
+      resolveRun({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+async function readLatestLogTail(): Promise<DiagnosticReport["logs"]> {
+  const logsDir = resolve("logs");
+  const entries = await readdir(logsDir).catch(() => []);
+  const candidates = await Promise.all(
+    entries
+      .filter((entry) => /^pc-bridge-watch-.*\.log$/i.test(entry))
+      .map(async (entry) => {
+        const path = join(logsDir, entry);
+        return {
+          entry,
+          path,
+          stats: await stat(path),
+        };
+      }),
+  );
+  const latest = candidates.sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs)[0];
+
+  if (!latest) {
+    return {};
+  }
+
+  const text = await readFile(latest.path, "utf8");
+  return {
+    latestLogFile: latest.entry,
+    latestLogUpdatedAt: latest.stats.mtime.toISOString(),
+    redactedTail: tail(redactSensitiveText(text), 4000),
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tail(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `...${value.slice(value.length - maxLength + 3)}`;
+}
+
+function maskId(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.length <= 8 ? "***" : `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function maskProjectId(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const [prefix] = value.split("-");
+  return `${prefix}-***`;
+}
+
+function maskPath(value: string): string {
+  const normalized = value.replace(/\\/g, "/");
+  const parts = normalized.split("/").filter((part) => part.length > 0);
+  return parts.length <= 2 ? normalized : `.../${parts.slice(-2).join("/")}`;
+}


### PR DESCRIPTION
## 概要
- PCブリッジに 
pm.cmd run diagnose を追加
- config検証、Node/Codex CLI検出、redaction済みログ末尾を安全なJSONで出力
- docs/diagnostics-runbook.md にAndroid/PC/Firebase別の収集手順と報告テンプレートを追加
- GitHub bug reportテンプレートを診断情報中心に更新

## 検証
- npm.cmd run check
- npm.cmd run test
- npm.cmd run diagnose
- npm.cmd run validate:local
- git diff --check

補足: スマホ実機操作は行っていません。Android側の確認項目は利用者が確認する手順としてRunbookに分離しています。

Closes #157