### PR TITLE
test: release E2E smoke tooling

### DIFF
--- a/docs/release-e2e-smoke.md
+++ b/docs/release-e2e-smoke.md
@@ -1,0 +1,132 @@
+# Release E2E smoke runbook
+
+Release前の実機E2E smokeは、Android実機、Firebase、PCブリッジを同じ検証用Firebaseプロジェクトに接続して実施する。ホスト済みFirebaseや共有サービスアカウントは使わない。
+
+## 前提
+
+- Android実機がUSBデバッグまたはワイヤレスデバッグでPCから見える。
+- `flutter devices` にAndroid実機が表示される。
+- `adb`、`flutter`、Node.js 22以上、npmが利用できる。
+- `pc-bridge/config.local.json` が検証用Firebase、検証用service account、対象workspaceを指している。
+- APKをインストールする場合は、release APKを事前に作成するか、debug APKで確認する。
+
+## 半自動チェック
+
+端末検出、APK情報、インストール済みアプリのversion、直近logcatをJSONで取得する。
+
+```powershell
+.\scripts\run-android-e2e-smoke.ps1 `
+  -EvidencePath .\docs\releases\e2e-smoke-<version>.json
+```
+
+debug APKをビルドして実機へ入れる場合:
+
+```powershell
+.\scripts\run-android-e2e-smoke.ps1 `
+  -BuildDebug `
+  -Install `
+  -EvidencePath .\docs\releases\e2e-smoke-debug.json
+```
+
+release APKを明示して入れる場合:
+
+```powershell
+.\scripts\run-android-e2e-smoke.ps1 `
+  -Install `
+  -ApkPath .\app\build\app\outputs\flutter-apk\app-release.apk `
+  -EvidencePath .\docs\releases\e2e-smoke-<version>.json
+```
+
+複数端末がある場合は `-DeviceId` を指定する。
+
+## 手動操作ポイント
+
+1. アプリを起動する。
+2. Firebase setup QRを読み込む、または保存済みFirebase設定で起動できることを確認する。
+3. 通知許可ダイアログが出る場合は許可する。
+4. PCブリッジ表示で対象ブリッジがactiveまたは直近heartbeatありになることを確認する。
+5. `Check PC now` を実行し、応答時刻が更新されることを確認する。
+6. 新規セッションを作成する。
+7. セッション詳細から短いコマンドを送信する。
+8. PCブリッジが処理し、アプリ上でcommandが `completed` になることを確認する。
+9. 完了通知が端末に届くことを確認する。
+
+## PCブリッジ実行
+
+手元のターミナルでログを見ながら実行する。
+
+```powershell
+Set-Location pc-bridge
+npm.cmd run start:watch
+```
+
+別ターミナルで診断情報を取得する。
+
+```powershell
+Set-Location pc-bridge
+npm.cmd run diagnose
+```
+
+## Firestore証跡
+
+最新セッションと最新command、PCブリッジheartbeat、通知送信カウントをJSONで取得する。
+
+```powershell
+Set-Location pc-bridge
+npm.cmd run e2e:evidence
+```
+
+特定のセッションまたはcommandを指定する場合:
+
+```powershell
+npm.cmd run e2e:evidence -- --session-id <sessionId> --command-id <commandId>
+```
+
+確認する主な項目:
+
+- `pcBridge.status`: `active`
+- `pcBridge.lastSeenAt`: release smoke実施中の時刻
+- `pcBridge.lastHealthCheckStatus`: `responded`
+- `session.status`: `completed`
+- `command.status`: `completed`
+- `command.notificationSuccessCount`: `1` 以上
+- `command.notificationFailureCount`: `0`
+
+## 失敗時の切り分け
+
+- 端末が見えない: `flutter devices --machine` と `adb devices -l` を確認する。ワイヤレスデバッグはペアリング後に接続が切れていないか確認する。
+- APK install失敗: 既存アプリの署名違い、端末空き容量、Androidの提供元不明アプリ設定を確認する。
+- Firebase setup失敗: QRのproject ID、API key、app ID、sender IDを確認する。秘密情報をIssueへ貼らない。
+- PCブリッジがactiveにならない: `pc-bridge/config.local.json`、service account path、`npm.cmd run diagnose`、watcherログを確認する。
+- commandがqueuedのまま: `targetPcBridgeId` がPCブリッジの `pcBridgeId` と一致しているか確認する。
+- commandがfailedになる: watcherログとCodex CLIのexit codeを確認する。
+- 通知が届かない: Android通知許可、FCM token登録、Functionsログ、`notificationFailureCount` と `notificationLastError` を確認する。
+
+## Release evidenceテンプレート
+
+```markdown
+## E2E smoke evidence
+
+- Date:
+- App versionName/versionCode:
+- Device:
+- Android version:
+- Install method: release APK / debug APK / existing install
+- Firebase project: masked project ID only
+- PC bridge: active, lastSeenAt=
+- Health check: responded, requestedAt=, respondedAt=
+- Session ID:
+- Command ID:
+- Command status: completed
+- notificationSuccessCount:
+- notificationFailureCount:
+- Manual checks:
+  - Firebase setup:
+  - Notification permission:
+  - Session creation:
+  - Command completion on device:
+  - Completion notification:
+- Evidence files:
+  - scripts/run-android-e2e-smoke.ps1 output:
+  - npm.cmd run e2e:evidence output:
+```

--- a/pc-bridge/package.json
+++ b/pc-bridge/package.json
@@ -12,6 +12,7 @@
     "test": "tsc && node --test \"dist/tests/**/*.test.js\"",
     "validate:local": "tsc && node dist/scripts/validate-local-relay.js",
     "diagnose": "tsc && node dist/scripts/collect-diagnostics.js",
+    "e2e:evidence": "tsc && node dist/scripts/collect-e2e-evidence.js",
     "qr:firebase": "tsc && node dist/scripts/generate-firebase-setup-qr.js",
     "setup:web": "tsc && node dist/scripts/setup-web.js",
     "package:dist": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-distribution.ps1"

--- a/pc-bridge/scripts/collect-e2e-evidence.ts
+++ b/pc-bridge/scripts/collect-e2e-evidence.ts
@@ -1,0 +1,184 @@
+import { readFile } from "node:fs/promises";
+import { cert, getApps, initializeApp } from "firebase-admin/app";
+import { Timestamp, getFirestore, type DocumentData } from "firebase-admin/firestore";
+import { loadBridgeConfig } from "../src/lib/config.js";
+import { redactSensitiveText } from "../src/lib/redaction.js";
+
+type Args = {
+  configPath: string;
+  uid?: string;
+  sessionId?: string;
+  commandId?: string;
+};
+
+const args = parseArgs(process.argv.slice(2));
+const config = await loadBridgeConfig(args.configPath);
+const userId = args.uid ?? config.ownerUserId;
+
+if (!userId) {
+  throw new Error("Pass --uid or set ownerUserId in config.local.json.");
+}
+
+if (!config.firebaseProjectId || !config.serviceAccountPath) {
+  throw new Error("Firestore evidence requires firebaseProjectId and serviceAccountPath in config.local.json.");
+}
+
+const serviceAccount = JSON.parse(await readFile(config.serviceAccountPath, "utf8")) as object;
+const appName = `codex-remote-e2e-${config.pcBridgeId}`;
+const app = getApps().find((candidate) => candidate.name === appName) ??
+  initializeApp(
+    {
+      credential: cert(serviceAccount),
+      projectId: config.firebaseProjectId,
+    },
+    appName,
+  );
+const firestore = getFirestore(app);
+
+const sessionDoc = args.sessionId
+  ? await firestore.doc(`users/${userId}/sessions/${args.sessionId}`).get()
+  : await latestDoc(`users/${userId}/sessions`, "updatedAt");
+
+const commandDoc = sessionDoc?.exists
+  ? args.commandId
+    ? await sessionDoc.ref.collection("commands").doc(args.commandId).get()
+    : await latestDoc(`${sessionDoc.ref.path}/commands`, "createdAt")
+  : undefined;
+
+const bridgeDoc = await firestore.doc(`users/${userId}/pcBridges/${config.pcBridgeId}`).get();
+
+const evidence = {
+  generatedAt: new Date().toISOString(),
+  firebase: {
+    projectId: maskProjectId(config.firebaseProjectId),
+    userId: maskId(userId),
+    pcBridgeId: maskId(config.pcBridgeId),
+  },
+  pcBridge: bridgeDoc.exists ? summarizeBridge(bridgeDoc.data()) : { exists: false },
+  session: sessionDoc?.exists ? summarizeSession(sessionDoc.id, sessionDoc.data()) : { exists: false },
+  command: commandDoc?.exists ? summarizeCommand(commandDoc.id, commandDoc.data()) : { exists: false },
+};
+
+console.log(JSON.stringify(evidence, null, 2));
+
+async function latestDoc(collectionPath: string, orderByField: string) {
+  const snapshot = await firestore.collection(collectionPath).orderBy(orderByField, "desc").limit(1).get();
+  return snapshot.docs[0];
+}
+
+function summarizeBridge(data: DocumentData | undefined) {
+  return {
+    exists: true,
+    status: optionalString(data?.status),
+    displayName: optionalString(data?.displayName),
+    workspaceName: optionalString(data?.workspaceName),
+    lastSeenAt: timestampToIso(data?.lastSeenAt),
+    lastQueueCheckedAt: timestampToIso(data?.lastQueueCheckedAt),
+    lastHealthCheckRequestedAt: timestampToIso(data?.lastHealthCheckRequestedAt),
+    lastHealthCheckRespondedAt: timestampToIso(data?.lastHealthCheckRespondedAt),
+    lastHealthCheckStatus: optionalString(data?.lastHealthCheckStatus),
+  };
+}
+
+function summarizeSession(id: string, data: DocumentData | undefined) {
+  return {
+    id,
+    title: redact(data?.title),
+    status: optionalString(data?.status),
+    updatedAt: timestampToIso(data?.updatedAt),
+    lastCommandId: optionalString(data?.lastCommandId),
+    lastResultPreview: redact(data?.lastResultPreview),
+    lastErrorPreview: redact(data?.lastErrorPreview),
+  };
+}
+
+function summarizeCommand(id: string, data: DocumentData | undefined) {
+  return {
+    exists: true,
+    id,
+    text: redact(data?.text),
+    status: optionalString(data?.status),
+    targetPcBridgeId: maskId(optionalString(data?.targetPcBridgeId)),
+    claimedByPcBridgeId: maskId(optionalString(data?.claimedByPcBridgeId)),
+    createdAt: timestampToIso(data?.createdAt),
+    startedAt: timestampToIso(data?.startedAt),
+    completedAt: timestampToIso(data?.completedAt),
+    notificationSentAt: timestampToIso(data?.notificationSentAt),
+    notificationSuccessCount: numberOrNull(data?.notificationSuccessCount),
+    notificationFailureCount: numberOrNull(data?.notificationFailureCount),
+    notificationLastError: redact(data?.notificationLastError),
+    resultPreview: preview(redact(data?.resultText)),
+    errorPreview: preview(redact(data?.errorText)),
+  };
+}
+
+function parseArgs(values: string[]): Args {
+  const result: Args = {
+    configPath: process.env.CODEX_REMOTE_BRIDGE_CONFIG ?? "config.local.json",
+  };
+
+  for (let index = 0; index < values.length; index += 1) {
+    const value = values[index];
+    const next = values[index + 1];
+    if (value === "--config" && next) {
+      result.configPath = next;
+      index += 1;
+    } else if (value === "--uid" && next) {
+      result.uid = next;
+      index += 1;
+    } else if (value === "--session-id" && next) {
+      result.sessionId = next;
+      index += 1;
+    } else if (value === "--command-id" && next) {
+      result.commandId = next;
+      index += 1;
+    }
+  }
+
+  return result;
+}
+
+function timestampToIso(value: unknown): string | undefined {
+  if (value instanceof Timestamp) {
+    return value.toDate().toISOString();
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+
+  return undefined;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}
+
+function redact(value: unknown): string | undefined {
+  return typeof value === "string" ? redactSensitiveText(value) : undefined;
+}
+
+function preview(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.length <= 240 ? value : `${value.slice(0, 237)}...`;
+}
+
+function maskId(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.length <= 8 ? "***" : `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function maskProjectId(value: string): string {
+  const [prefix] = value.split("-");
+  return `${prefix}-***`;
+}

--- a/scripts/run-android-e2e-smoke.ps1
+++ b/scripts/run-android-e2e-smoke.ps1
@@ -1,0 +1,130 @@
+param(
+  [string]$DeviceId = "",
+  [string]$PackageName = "com.sunmax.remotecodex",
+  [string]$ApkPath = "app\build\app\outputs\flutter-apk\app-release.apk",
+  [switch]$BuildDebug,
+  [switch]$Install,
+  [string]$EvidencePath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$AppDir = Join-Path $RepoRoot "app"
+
+function Invoke-Checked {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments,
+    [string]$WorkingDirectory = $RepoRoot
+  )
+
+  Push-Location $WorkingDirectory
+  try {
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+      throw "$FilePath exited with code $LASTEXITCODE"
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
+function Read-FlutterAndroidDevice {
+  if ($DeviceId.Trim().Length -gt 0) {
+    return $DeviceId
+  }
+
+  $devicesJson = & flutter devices --machine
+  if ($LASTEXITCODE -ne 0) {
+    throw "flutter devices --machine failed."
+  }
+
+  $devices = $devicesJson | ConvertFrom-Json
+  $androidDevices = @($devices | Where-Object { $_.targetPlatform -like "android*" })
+  if ($androidDevices.Count -eq 0) {
+    throw "No Android device was found. Connect a physical device with USB or wireless debugging."
+  }
+
+  return $androidDevices[0].id
+}
+
+$ResolvedDeviceId = Read-FlutterAndroidDevice
+
+if ($BuildDebug) {
+  Invoke-Checked -FilePath "flutter" -Arguments @("build", "apk", "--debug") -WorkingDirectory $AppDir
+  $ApkPath = "app\build\app\outputs\flutter-apk\app-debug.apk"
+}
+
+$ResolvedApkPath = Join-Path $RepoRoot $ApkPath
+
+if ($Install) {
+  if (-not (Test-Path -LiteralPath $ResolvedApkPath)) {
+    throw "APK was not found: $ResolvedApkPath"
+  }
+
+  Invoke-Checked -FilePath "adb" -Arguments @("-s", $ResolvedDeviceId, "install", "-r", $ResolvedApkPath)
+}
+
+$DeviceInfo = [ordered]@{
+  id = $ResolvedDeviceId
+  model = (& adb -s $ResolvedDeviceId shell getprop ro.product.model).Trim()
+  androidVersion = (& adb -s $ResolvedDeviceId shell getprop ro.build.version.release).Trim()
+  sdk = (& adb -s $ResolvedDeviceId shell getprop ro.build.version.sdk).Trim()
+}
+
+$PackageInfoText = & adb -s $ResolvedDeviceId shell dumpsys package $PackageName
+$PackageInfo = ($PackageInfoText -join "`n")
+$PackageInstalled = $LASTEXITCODE -eq 0 -and $PackageInfo.Contains($PackageName)
+$VersionName = $null
+$VersionCode = $null
+$VersionNameMatch = [regex]::Match($PackageInfo, "versionName=([^\s]+)")
+if ($VersionNameMatch.Success) {
+  $VersionName = $VersionNameMatch.Groups[1].Value
+}
+$VersionCodeMatch = [regex]::Match($PackageInfo, "versionCode=(\d+)")
+if ($VersionCodeMatch.Success) {
+  $VersionCode = $VersionCodeMatch.Groups[1].Value
+}
+
+$LogcatText = & adb -s $ResolvedDeviceId logcat -d -t 200 2>$null
+$RemoteCodexLogTail = @($LogcatText | Select-String -Pattern "RemoteCodex|Flutter|FirebaseMessaging" -CaseSensitive:$false | Select-Object -Last 40 | ForEach-Object { $_.Line })
+
+$Evidence = [ordered]@{
+  generatedAt = (Get-Date).ToUniversalTime().ToString("o")
+  device = $DeviceInfo
+  package = [ordered]@{
+    name = $PackageName
+    installed = $PackageInstalled
+    versionName = $VersionName
+    versionCode = $VersionCode
+  }
+  apk = [ordered]@{
+    path = $ResolvedApkPath
+    exists = Test-Path -LiteralPath $ResolvedApkPath
+    installedDuringRun = [bool]$Install
+    builtDebugDuringRun = [bool]$BuildDebug
+  }
+  manualChecks = [ordered]@{
+    firebaseSetupQrScanned = "fill after manual check"
+    notificationPermission = "fill after manual check"
+    sessionCreated = "fill after manual check"
+    commandSent = "fill after manual check"
+    commandCompletedOnDevice = "fill after manual check"
+    notificationReceived = "fill after manual check"
+  }
+  logcatTail = $RemoteCodexLogTail
+}
+
+$Json = $Evidence | ConvertTo-Json -Depth 8
+
+if ($EvidencePath.Trim().Length -gt 0) {
+  $ResolvedEvidencePath = Join-Path $RepoRoot $EvidencePath
+  $EvidenceDir = Split-Path -Parent $ResolvedEvidencePath
+  if ($EvidenceDir -and -not (Test-Path -LiteralPath $EvidenceDir)) {
+    New-Item -ItemType Directory -Force -Path $EvidenceDir | Out-Null
+  }
+  Set-Content -LiteralPath $ResolvedEvidencePath -Value $Json -Encoding utf8
+}
+
+$Json


### PR DESCRIPTION
## Summary
- 実機E2E smokeのRunbookを追加し、手動操作ポイント・失敗時切り分け・Release evidenceテンプレートを明記
- Android実機の検出、APK install、version/logcat証跡を取得するPowerShell補助スクリプトを追加
- PCブリッジ側にFirestoreのセッション/command/通知カウント証跡をJSON出力する 
pm.cmd run e2e:evidence を追加

## Validation
- flutter test
- npm.cmd run check
- npm.cmd test
- .\\scripts\\run-android-e2e-smoke.ps1
- npm.cmd run e2e:evidence

Closes #155