### PR TITLE
feat: setup web PC bridge operations

### DIFF
--- a/pc-bridge/scripts/setup-web.ts
+++ b/pc-bridge/scripts/setup-web.ts
@@ -1,12 +1,16 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { readFile } from "node:fs/promises";
+import { access, readFile, readdir, stat } from "node:fs/promises";
+import { constants } from "node:fs";
+import { spawn } from "node:child_process";
 import { extname, join, normalize, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadBridgeConfig } from "../src/lib/config.js";
 import {
   buildFirebaseSetupPayload,
   firebaseSetupPayloadToDataUrl,
   parseGoogleServicesJson,
 } from "../src/lib/firebaseSetupQr.js";
+import { redactSensitiveText } from "../src/lib/redaction.js";
 
 type GenerateRequest = {
   googleServicesJson?: string;
@@ -30,6 +34,21 @@ const server = createServer(async (request, response) => {
   try {
     if (request.method === "POST" && request.url === "/api/firebase-setup-qr") {
       await handleGenerateQr(request, response);
+      return;
+    }
+
+    if (request.method === "GET" && request.url === "/api/pc-bridge/status") {
+      await handleBridgeStatus(response);
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/api/pc-bridge/start") {
+      await handleBridgeStart(response);
+      return;
+    }
+
+    if (request.method === "POST" && request.url === "/api/pc-bridge/register-task") {
+      await handleBridgeRegisterTask(response);
       return;
     }
 
@@ -74,6 +93,74 @@ async function handleGenerateQr(
   const qrDataUrl = await firebaseSetupPayloadToDataUrl(payload);
 
   sendJson(response, 200, { payload, qrDataUrl });
+}
+
+async function handleBridgeStatus(response: ServerResponse): Promise<void> {
+  const configPath = resolve(process.env.CODEX_REMOTE_BRIDGE_CONFIG ?? "config.local.json");
+  const report: Record<string, unknown> = {
+    generatedAt: new Date().toISOString(),
+    config: {
+      path: maskPath(configPath),
+      exists: await exists(configPath),
+      valid: false,
+    },
+    process: await inspectBridgeProcess(),
+    logs: await readLatestBridgeLog(),
+  };
+
+  try {
+    const config = await loadBridgeConfig(configPath);
+    const serviceAccountPathExists = config.serviceAccountPath
+      ? await exists(config.serviceAccountPath)
+      : false;
+
+    report.config = {
+      path: maskPath(configPath),
+      exists: true,
+      valid: true,
+      relayMode: config.relayMode,
+      codexMode: config.codexMode,
+      pcBridgeId: maskId(config.pcBridgeId),
+      firebaseProjectId: maskProjectId(config.firebaseProjectId),
+      serviceAccountConfigured: typeof config.serviceAccountPath === "string" && config.serviceAccountPath.length > 0,
+      serviceAccountPathExists,
+      workspaceConfigured: config.workspacePath.length > 0,
+      classification: classifyConfigState(null, serviceAccountPathExists),
+    };
+  } catch (error) {
+    report.config = {
+      path: maskPath(configPath),
+      exists: await exists(configPath),
+      valid: false,
+      error: redactSensitiveText(error instanceof Error ? error.message : String(error)),
+      classification: classifyConfigState(error, false),
+    };
+  }
+
+  sendJson(response, 200, report);
+}
+
+async function handleBridgeStart(response: ServerResponse): Promise<void> {
+  const scriptPath = join(rootDir, "scripts", "start-watch-background.bat");
+  const child = spawn(scriptPath, {
+    cwd: rootDir,
+    detached: true,
+    shell: false,
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  child.unref();
+  sendJson(response, 200, { started: true, script: "scripts/start-watch-background.bat" });
+}
+
+async function handleBridgeRegisterTask(response: ServerResponse): Promise<void> {
+  const scriptPath = join(rootDir, "scripts", "register-watch-task.bat");
+  const result = await runCommand(scriptPath, [], rootDir);
+  sendJson(response, result.exitCode === 0 ? 200 : 500, {
+    exitCode: result.exitCode,
+    stdout: redactSensitiveText(result.stdout),
+    stderr: redactSensitiveText(result.stderr),
+  });
 }
 
 async function serveStatic(
@@ -134,4 +221,173 @@ function sendText(
     "Cache-Control": "no-store",
   });
   response.end(body);
+}
+
+async function inspectBridgeProcess(): Promise<Record<string, unknown>> {
+  if (process.platform !== "win32") {
+    return {
+      supported: false,
+      running: false,
+      note: "Process inspection is currently implemented for Windows.",
+    };
+  }
+
+  const result = await runCommand(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-Command",
+      "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -match 'dist[\\\\/]+src[\\\\/]+watch.js|start:watch|run-watch.bat' } | Select-Object ProcessId,Name,CommandLine | ConvertTo-Json -Depth 4",
+    ],
+    rootDir,
+  );
+
+  if (result.exitCode !== 0) {
+    return {
+      supported: true,
+      running: false,
+      error: redactSensitiveText(result.stderr || result.stdout),
+    };
+  }
+
+  const trimmed = result.stdout.trim();
+  if (!trimmed) {
+    return { supported: true, running: false, matches: [] };
+  }
+
+  const parsed = JSON.parse(trimmed) as unknown;
+  const matches = (Array.isArray(parsed) ? parsed : [parsed]).filter(
+    (entry) =>
+      !String((entry as Record<string, unknown>).CommandLine ?? "").includes(
+        "Get-CimInstance Win32_Process",
+      ),
+  );
+  return {
+    supported: true,
+    running: matches.length > 0,
+    matches: matches.map((entry) => redactProcessEntry(entry)),
+  };
+}
+
+async function readLatestBridgeLog(): Promise<Record<string, unknown>> {
+  const logsDir = join(rootDir, "logs");
+  const entries = await readdir(logsDir).catch(() => []);
+  const candidates = await Promise.all(
+    entries
+      .filter((entry) => /^pc-bridge-watch-.*\.log$/i.test(entry))
+      .map(async (entry) => {
+        const path = join(logsDir, entry);
+        return { entry, path, stats: await stat(path) };
+      }),
+  );
+  const latest = candidates.sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs)[0];
+  if (!latest) {
+    return { found: false };
+  }
+
+  const text = await readFile(latest.path, "utf8");
+  return {
+    found: true,
+    file: latest.entry,
+    updatedAt: latest.stats.mtime.toISOString(),
+    redactedTail: tail(redactSensitiveText(text), 6000),
+  };
+}
+
+function runCommand(command: string, args: string[], cwd: string): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolveRun) => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      resolveRun({ exitCode: 1, stdout, stderr: stderr + error.message });
+    });
+    child.on("close", (exitCode) => {
+      resolveRun({ exitCode, stdout, stderr });
+    });
+  });
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function redactProcessEntry(value: unknown): unknown {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const entry = value as Record<string, unknown>;
+  return {
+    processId: entry.ProcessId,
+    name: entry.Name,
+    commandLine: typeof entry.CommandLine === "string" ? redactSensitiveText(entry.CommandLine) : entry.CommandLine,
+  };
+}
+
+function classifyConfigState(error: unknown, serviceAccountPathExists: boolean): string {
+  if (!error) {
+    return serviceAccountPathExists ? "ready" : "service-account-path-missing";
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("ENOENT") || message.includes("no such file")) {
+    return "config-file-missing";
+  }
+  if (message.includes("Missing required bridge config field")) {
+    return "config-required-field-missing";
+  }
+  if (message.includes("Unsupported")) {
+    return "config-value-unsupported";
+  }
+  if (message.includes("JSON")) {
+    return "config-json-invalid";
+  }
+  return "config-error";
+}
+
+function maskId(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  return value.length <= 8 ? "***" : `${value.slice(0, 4)}...${value.slice(-4)}`;
+}
+
+function maskProjectId(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const [prefix] = value.split("-");
+  return `${prefix}-***`;
+}
+
+function maskPath(value: string): string {
+  const normalized = value.replace(/\\/g, "/");
+  const parts = normalized.split("/").filter((part) => part.length > 0);
+  return parts.length <= 2 ? normalized : `.../${parts.slice(-2).join("/")}`;
+}
+
+function tail(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `...${value.slice(value.length - maxLength + 3)}`;
 }

--- a/pc-bridge/setup-web/app.js
+++ b/pc-bridge/setup-web/app.js
@@ -54,6 +54,23 @@ const messages = {
     configReady: "config.local.json template is ready.",
     configCopied: "config.local.json template copied.",
     configCopyFailed: "Copy failed. Select the text and copy it manually.",
+    bridgeOpsTitle: "PC Bridge Operations",
+    bridgeOpsSubtitle:
+      "Check config.local.json, watcher state, scheduled startup, and redacted logs from this local setup UI.",
+    refreshBridgeStatus: "Refresh status",
+    startBridge: "Start watcher",
+    registerBridgeTask: "Register on-login task",
+    bridgeConfigStatusTitle: "Config status",
+    bridgeProcessStatusTitle: "Process status",
+    bridgeLogTitle: "Latest redacted watcher log",
+    bridgeLogEmpty: "No log loaded.",
+    bridgeOpsReady: "Ready.",
+    bridgeStatusLoading: "Checking PC bridge status...",
+    bridgeStartRequested: "Watcher start was requested. Refresh status after a few seconds.",
+    bridgeTaskRegistered: "On-login task registration completed.",
+    bridgeActionFailed: (message) => `PC bridge action failed: ${message}`,
+    statusYes: "yes",
+    statusNo: "no",
     googleServicesPackageOk: "Android package matches com.sunmax.remotecodex.",
     googleServicesPackageMissing:
       "Android package com.sunmax.remotecodex was not found.",
@@ -156,6 +173,23 @@ const messages = {
     configReady: "config.local.jsonの雛形を生成しました。",
     configCopied: "config.local.jsonの雛形をコピーしました。",
     configCopyFailed: "コピーに失敗しました。テキストを選択して手動でコピーしてください。",
+    bridgeOpsTitle: "PCブリッジ運用",
+    bridgeOpsSubtitle:
+      "このローカルセットアップUIからconfig.local.json、watcher状態、常駐化、redaction済みログを確認します。",
+    refreshBridgeStatus: "状態を更新",
+    startBridge: "watcherを起動",
+    registerBridgeTask: "ログオン時タスクを登録",
+    bridgeConfigStatusTitle: "設定状態",
+    bridgeProcessStatusTitle: "プロセス状態",
+    bridgeLogTitle: "最新のredaction済みwatcherログ",
+    bridgeLogEmpty: "ログはまだ読み込まれていません。",
+    bridgeOpsReady: "準備完了。",
+    bridgeStatusLoading: "PCブリッジ状態を確認中...",
+    bridgeStartRequested: "watcher起動を要求しました。数秒後に状態を更新してください。",
+    bridgeTaskRegistered: "ログオン時タスクの登録が完了しました。",
+    bridgeActionFailed: (message) => `PCブリッジ操作に失敗しました: ${message}`,
+    statusYes: "はい",
+    statusNo: "いいえ",
     googleServicesPackageOk: "Android packageがcom.sunmax.remotecodexと一致しています。",
     googleServicesPackageMissing:
       "Android package com.sunmax.remotecodex が見つかりません。",
@@ -252,6 +286,23 @@ const messages = {
     configReady: "config.local.json 模板已准备好。",
     configCopied: "config.local.json 模板已复制。",
     configCopyFailed: "复制失败。请选中文本后手动复制。",
+    bridgeOpsTitle: "PC 桥接运行",
+    bridgeOpsSubtitle:
+      "从本地设置 UI 检查 config.local.json、watcher 状态、常驻启动和已脱敏日志。",
+    refreshBridgeStatus: "刷新状态",
+    startBridge: "启动 watcher",
+    registerBridgeTask: "登记登录时任务",
+    bridgeConfigStatusTitle: "设置状态",
+    bridgeProcessStatusTitle: "进程状态",
+    bridgeLogTitle: "最新脱敏 watcher 日志",
+    bridgeLogEmpty: "尚未加载日志。",
+    bridgeOpsReady: "就绪。",
+    bridgeStatusLoading: "正在检查 PC 桥接状态...",
+    bridgeStartRequested: "已请求启动 watcher。请几秒后刷新状态。",
+    bridgeTaskRegistered: "登录时任务登记已完成。",
+    bridgeActionFailed: (message) => `PC 桥接操作失败: ${message}`,
+    statusYes: "是",
+    statusNo: "否",
     googleServicesPackageOk: "Android package 与 com.sunmax.remotecodex 一致。",
     googleServicesPackageMissing:
       "未找到 Android package com.sunmax.remotecodex。",
@@ -318,6 +369,13 @@ const workspacePath = document.querySelector("#workspacePath");
 const configPreview = document.querySelector("#configPreview");
 const copyConfig = document.querySelector("#copyConfig");
 const configStatus = document.querySelector("#configStatus");
+const refreshBridgeStatus = document.querySelector("#refreshBridgeStatus");
+const startBridge = document.querySelector("#startBridge");
+const registerBridgeTask = document.querySelector("#registerBridgeTask");
+const bridgeConfigStatus = document.querySelector("#bridgeConfigStatus");
+const bridgeProcessStatus = document.querySelector("#bridgeProcessStatus");
+const bridgeLogTail = document.querySelector("#bridgeLogTail");
+const bridgeOpsStatus = document.querySelector("#bridgeOpsStatus");
 const generateQr = document.querySelector("#generateQr");
 const saveLocal = document.querySelector("#saveLocal");
 const clearLocal = document.querySelector("#clearLocal");
@@ -331,6 +389,7 @@ let lastPayload = null;
 languageSelect.value = currentLanguage;
 applyLanguage();
 loadLocalState();
+refreshPcBridgeStatus();
 
 languageSelect.addEventListener("change", () => {
   currentLanguage = languageSelect.value;
@@ -409,6 +468,21 @@ copyConfig.addEventListener("click", async () => {
     configPreview.select();
     setStatus(configStatus, t("configCopyFailed"), true);
   }
+});
+
+refreshBridgeStatus.addEventListener("click", () => {
+  refreshPcBridgeStatus();
+});
+
+startBridge.addEventListener("click", async () => {
+  await postBridgeAction("/api/pc-bridge/start", t("bridgeStartRequested"));
+});
+
+registerBridgeTask.addEventListener("click", async () => {
+  await postBridgeAction(
+    "/api/pc-bridge/register-task",
+    t("bridgeTaskRegistered"),
+  );
 });
 
 generateQr.addEventListener("click", async () => {
@@ -547,6 +621,101 @@ function detectInitialLanguage() {
   if (browserLanguage.startsWith("ja")) return "ja";
   if (browserLanguage.startsWith("zh")) return "zh";
   return "en";
+}
+
+async function refreshPcBridgeStatus() {
+  setStatus(bridgeOpsStatus, t("bridgeStatusLoading"), false);
+  try {
+    const response = await fetch("/api/pc-bridge/status", {
+      headers: { Accept: "application/json" },
+    });
+    const report = await response.json();
+    if (!response.ok) {
+      throw new Error(report.error ?? response.statusText);
+    }
+
+    renderStatusList(bridgeConfigStatus, {
+      path: report.config?.path,
+      exists: yesNo(report.config?.exists),
+      valid: yesNo(report.config?.valid),
+      classification: report.config?.classification,
+      relayMode: report.config?.relayMode,
+      codexMode: report.config?.codexMode,
+      pcBridgeId: report.config?.pcBridgeId,
+      firebaseProjectId: report.config?.firebaseProjectId,
+      serviceAccountConfigured: yesNo(report.config?.serviceAccountConfigured),
+      serviceAccountPathExists: yesNo(report.config?.serviceAccountPathExists),
+      workspaceConfigured: yesNo(report.config?.workspaceConfigured),
+      error: report.config?.error,
+    });
+
+    renderStatusList(bridgeProcessStatus, {
+      supported: yesNo(report.process?.supported),
+      running: yesNo(report.process?.running),
+      matches: Array.isArray(report.process?.matches)
+        ? String(report.process.matches.length)
+        : undefined,
+      error: report.process?.error,
+    });
+
+    if (report.logs?.found) {
+      bridgeLogTail.textContent =
+        `# ${report.logs.file} (${report.logs.updatedAt})\n` +
+        (report.logs.redactedTail ?? "");
+    } else {
+      bridgeLogTail.textContent = t("bridgeLogEmpty");
+    }
+
+    setStatus(bridgeOpsStatus, t("ready"), false);
+  } catch (error) {
+    setStatus(
+      bridgeOpsStatus,
+      t("bridgeActionFailed", error instanceof Error ? error.message : String(error)),
+      true,
+    );
+  }
+}
+
+async function postBridgeAction(url, successMessage) {
+  setStatus(bridgeOpsStatus, t("bridgeStatusLoading"), false);
+  try {
+    const response = await fetch(url, { method: "POST" });
+    const result = await response.json();
+    if (!response.ok) {
+      throw new Error(result.stderr || result.error || response.statusText);
+    }
+    setStatus(bridgeOpsStatus, successMessage, false);
+    await refreshPcBridgeStatus();
+  } catch (error) {
+    setStatus(
+      bridgeOpsStatus,
+      t("bridgeActionFailed", error instanceof Error ? error.message : String(error)),
+      true,
+    );
+  }
+}
+
+function renderStatusList(container, entries) {
+  container.replaceChildren();
+  for (const [key, value] of Object.entries(entries)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+
+    const term = document.createElement("dt");
+    term.textContent = key;
+    const description = document.createElement("dd");
+    description.textContent = String(value);
+    container.append(term, description);
+  }
+}
+
+function yesNo(value) {
+  if (typeof value !== "boolean") {
+    return undefined;
+  }
+
+  return value ? t("statusYes") : t("statusNo");
 }
 
 function validateSetupInputs() {

--- a/pc-bridge/setup-web/index.html
+++ b/pc-bridge/setup-web/index.html
@@ -132,6 +132,31 @@
 
       <section class="panel span-2">
         <div class="section-heading">
+          <h2 data-i18n="bridgeOpsTitle">PC Bridge Operations</h2>
+          <p data-i18n="bridgeOpsSubtitle">Check config.local.json, watcher state, scheduled startup, and redacted logs from this local setup UI.</p>
+        </div>
+        <div class="actions">
+          <button id="refreshBridgeStatus" class="button primary" data-i18n="refreshBridgeStatus">Refresh status</button>
+          <button id="startBridge" class="button secondary" data-i18n="startBridge">Start watcher</button>
+          <button id="registerBridgeTask" class="button secondary" data-i18n="registerBridgeTask">Register on-login task</button>
+        </div>
+        <div class="bridge-status-grid">
+          <div>
+            <h3 data-i18n="bridgeConfigStatusTitle">Config status</h3>
+            <dl class="status-list" id="bridgeConfigStatus"></dl>
+          </div>
+          <div>
+            <h3 data-i18n="bridgeProcessStatusTitle">Process status</h3>
+            <dl class="status-list" id="bridgeProcessStatus"></dl>
+          </div>
+        </div>
+        <h3 data-i18n="bridgeLogTitle">Latest redacted watcher log</h3>
+        <pre id="bridgeLogTail" class="log-tail" data-i18n="bridgeLogEmpty">No log loaded.</pre>
+        <div class="status-line" id="bridgeOpsStatus" data-i18n="bridgeOpsReady">Ready.</div>
+      </section>
+
+      <section class="panel span-2">
+        <div class="section-heading">
           <h2 data-i18n="qrGeneratorTitle">QR Generator</h2>
           <p data-i18n="qrGeneratorSubtitle">Generate the Android setup QR for the distributed APK.</p>
         </div>

--- a/pc-bridge/setup-web/styles.css
+++ b/pc-bridge/setup-web/styles.css
@@ -218,6 +218,44 @@ textarea {
   min-height: 260px;
 }
 
+.bridge-status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.status-list {
+  display: grid;
+  grid-template-columns: 150px minmax(0, 1fr);
+  gap: 8px 12px;
+  margin: 0 0 16px;
+}
+
+.status-list dt {
+  color: var(--muted);
+}
+
+.status-list dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-family: Consolas, "Cascadia Mono", monospace;
+}
+
+.log-tail {
+  min-height: 180px;
+  max-height: 360px;
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  white-space: pre-wrap;
+  font-family: Consolas, "Cascadia Mono", monospace;
+  font-size: 12px;
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;
@@ -395,6 +433,7 @@ code {
   .layout,
   .two-column,
   .config-grid,
+  .bridge-status-grid,
   .qr-area,
   .link-grid {
     display: block;


### PR DESCRIPTION
## Summary
- セットアップWeb UIへPCブリッジ運用パネルを追加
- ローカルAPIでconfig.local.jsonの存在/必須項目/service account path、watcherプロセス、最新ログtailを確認
- watcher起動とログオン時タスク登録をローカルAPIから実行できる導線を追加
- 表示するログとプロセス情報はredaction済みで返す

## Validation
- node --check setup-web/app.js
- npm.cmd run check
- npm.cmd test
- GET http://127.0.0.1:8789/
- GET http://127.0.0.1:8789/api/pc-bridge/status

Closes #160