### PR TITLE
docs: Firebase cost guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ firebase deploy --only functions
 
 `firebase use --add` では、利用者自身が用意したFirebase project IDを選択します。Cloud Functionsの初回デプロイにはBlazeプランとGoogle Cloud APIの有効化が必要です。詳細は [Firebase手順](firebase/README.md) と [Cloud Functions手順](firebase/functions/README.md) を参照してください。
 
+### Firebase費用と課金注意点
+
+このアプリは利用者自身のFirebase/GCPプロジェクトを使うため、Firestore、Cloud Functions、Cloud Logging、Functions周辺のGoogle Cloudサービスで課金が発生し得ます。FCMはFirebaseのno-cost productとして扱われますが、完了通知を送るFunctionsやFirestoreの利用量は確認が必要です。
+
+少人数利用では通常、セッション/command数、PCブリッジのpolling、heartbeat、通知回数が主な利用量になります。Cloud Functionsを使うRelease相当の構成ではBlazeプランが必要です。セットアップ直後にGoogle Cloud BillingのBudgets & alertsで小さな予算アラートを設定してください。
+
+詳細と公式料金リンクは [Firebase費用ガイド](docs/firebase-cost-guide.md) を参照してください。
+
 ## 利用開始手順
 
 このアプリを使い始めるための準備は、[利用開始手順](docs/getting-started.md) を参照してください。自分以外の利用者へ配布するための準備は、[配布準備](docs/distribution-prep.md) を参照してください。

--- a/docs/firebase-cost-guide.md
+++ b/docs/firebase-cost-guide.md
@@ -1,0 +1,60 @@
+# Firebase cost guide
+
+Codex Remote Androidは、利用者自身のFirebase/GCPプロジェクトを使う。ホスト済みサービス方式は採用しないため、課金設定、予算アラート、利用量監視は利用者のプロジェクトで行う。
+
+Firebaseの料金と無料枠は変更される可能性がある。正確な金額と最新条件は、必ず公式ページを確認する。
+
+- Firebase pricing: <https://firebase.google.com/pricing>
+- Firebase pricing plans: <https://firebase.google.com/docs/projects/billing/firebase-pricing-plans>
+- Google Cloud Budgets & alerts: <https://docs.cloud.google.com/billing/docs/how-to/budgets>
+
+## このアプリで使う主なリソース
+
+| リソース | 使う場面 | 増えやすい操作 |
+| --- | --- | --- |
+| Firebase Authentication | Androidアプリの匿名UID作成 | 端末再インストール、複数端末利用 |
+| Cloud Firestore | セッション、コマンド、PCブリッジ状態、端末token、health check | セッション一覧表示、command送信、watcher polling、heartbeat |
+| Cloud Functions | command完了/失敗時のFCM通知 | command完了回数 |
+| Firebase Cloud Messaging | Androidへの完了通知 | command完了通知 |
+| Cloud Logging | Functionsログ、デプロイ/運用ログ | Functionsエラー、debugログ増加 |
+| Artifact Registry / Cloud Build / Cloud Run / Eventarc等 | Functions初回デプロイ時に有効化される場合がある周辺サービス | Functions deploy、Functions実行基盤 |
+
+## 少人数利用の目安
+
+個人または少人数で、1日に数十件程度のセッション/コマンドを扱う想定では、Firestore read/writeとFunctions invocationは小さくなりやすい。ただし、次の条件では増えやすい。
+
+- PCブリッジの `pollIntervalSeconds` を短くしすぎる。
+- セッション一覧を頻繁に開き直す。
+- 複数端末で同じFirebaseプロジェクトを共有する。
+- コマンドを大量に送る、または短い間隔で自動送信する。
+- Functionsで通知失敗が続き、ログが増える。
+
+## 無料枠とBlazeプラン
+
+Firebase公式ドキュメントでは、Sparkプランは支払い方法なしで始められ、Firestoreなど一部の有料対象プロダクトにも無料枠がある。一方、Cloud Functionsや追加のGoogle Cloudサービスを使うにはBlazeプランが必要になる。
+
+このアプリは完了通知にCloud Functionsを使うため、Release相当のFirebase構成ではBlazeプランが必要になる。Blazeは従量課金で、無料枠を超えた分や関連Google Cloudサービスの利用に課金が発生し得る。
+
+公式例では、Cloud Firestoreは1日あたり50,000 document readsと20,000 document writesが無料枠として説明されている。数値や対象サービスは変更される可能性があるため、運用前にFirebase pricingを確認する。
+
+## コストを抑える運用
+
+- このアプリ専用のFirebase/GCPプロジェクトを作る。
+- Google Cloud Consoleで予算と予算アラートを設定する。
+- `pollIntervalSeconds` は必要以上に短くしない。通常は既定値の5秒から始める。
+- 使わない検証プロジェクト、Functions、service account keyは削除する。
+- FunctionsログやCloud Loggingを定期的に確認する。
+- Firestoreに保存するcommand本文と結果は必要最小限にする。
+- 大量送信や自動連投は避ける。
+
+## 予算アラート
+
+Google CloudのBudgets & alertsは、BillingのCost managementから作成できる。単一プロジェクトだけを対象にした予算を作る場合は、対象Firebase/GCPプロジェクトを選択してからBillingへ進む。
+
+推奨:
+
+- 初回セットアップ直後に月額の小さな予算を設定する。
+- 50%、90%、100%など複数しきい値でメール通知を受ける。
+- Firebase/GCPプロジェクトを複数使う場合は、プロジェクト単位で予算スコープを確認する。
+
+予算アラートは通知であり、必ずしも利用を自動停止する仕組みではない。予期しない増加に気づくための安全策として扱う。

--- a/docs/user-quickstart.md
+++ b/docs/user-quickstart.md
@@ -178,6 +178,14 @@ firebase deploy --only functions
 
 初回デプロイではBlazeプランやGoogle Cloud APIの有効化が必要になる場合がある。
 
+## 10.1 Firebase費用と予算アラートを確認する
+
+このアプリは自分のFirebase/GCPプロジェクトを使う。ホスト済みサービス方式ではないため、課金と予算アラートは自分のプロジェクトで管理する。
+
+主に増える利用量は、Firestoreのread/write、PCブリッジのpollingとheartbeat、command完了時のCloud Functions invocation、Functions/Cloud Loggingのログである。FCM自体はFirebaseのno-cost productとして扱われるが、通知を送るFunctionsや周辺Google CloudサービスにはBlazeプランと従量課金が関係する。
+
+Google Cloud ConsoleのBillingでBudgets & alertsを作り、対象プロジェクトに小さな月額予算と複数しきい値の通知を設定する。詳細は [Firebase費用ガイド](firebase-cost-guide.md) を参照する。
+
 ## 11. PCブリッジを起動する
 
 PCブリッジのフォルダで起動する。

--- a/pc-bridge/setup-web/app.js
+++ b/pc-bridge/setup-web/app.js
@@ -25,6 +25,13 @@ const messages = {
     step6: "Create a PC bridge service account JSON and keep it local only.",
     step7: "Generate the QR and scan it from the Android setup screen.",
     step8: "Deploy Firestore rules, indexes, and Functions when needed.",
+    costNoticeTitle: "Firebase cost notice",
+    costNoticeSubtitle:
+      "This app uses your own Firebase/GCP project, so billing and budget alerts belong to that project.",
+    costNoticeBody:
+      "Firestore reads/writes, Cloud Functions invocations, Cloud Logging, and Functions-related Google Cloud services can create billable usage. FCM is listed by Firebase as a no-cost product, but the Cloud Function that sends completion notifications requires Blaze plan usage.",
+    firebasePricingLink: "Firebase pricing",
+    budgetAlertsLink: "Google Cloud budgets and alerts",
     appNameLabel: "App name",
     packageNameLabel: "Android package name",
     fixedAppInfoTitle: "Distributed APK settings",
@@ -144,6 +151,13 @@ const messages = {
     step6: "PCブリッジ用service account JSONを作成し、PC上だけで保管する。",
     step7: "QRを生成し、Androidのセットアップ画面から読み取る。",
     step8: "必要に応じてFirestore Rules、Indexes、Functionsをデプロイする。",
+    costNoticeTitle: "Firebase費用の注意",
+    costNoticeSubtitle:
+      "このアプリは自分のFirebase/GCPプロジェクトを使うため、課金と予算アラートもそのプロジェクトで管理します。",
+    costNoticeBody:
+      "Firestore read/write、Cloud Functions invocation、Cloud Logging、Functions関連のGoogle Cloudサービスで課金対象の利用が発生し得ます。FCMはFirebaseのno-cost productですが、完了通知を送るCloud FunctionにはBlazeプラン利用が関係します。",
+    firebasePricingLink: "Firebase料金",
+    budgetAlertsLink: "Google Cloud予算アラート",
     appNameLabel: "アプリ名",
     packageNameLabel: "Android package名",
     fixedAppInfoTitle: "配布APKの固定設定",
@@ -258,6 +272,13 @@ const messages = {
     step6: "创建 PC 桥接用 service account JSON，并只保存在本机。",
     step7: "生成二维码，并从 Android 设置画面扫描。",
     step8: "按需部署 Firestore rules、indexes 和 Functions。",
+    costNoticeTitle: "Firebase 费用提示",
+    costNoticeSubtitle:
+      "此应用使用你自己的 Firebase/GCP 项目，因此结算和预算提醒也由该项目管理。",
+    costNoticeBody:
+      "Firestore read/write、Cloud Functions invocation、Cloud Logging 以及 Functions 相关 Google Cloud 服务可能产生计费使用量。FCM 被 Firebase 列为 no-cost product，但发送完成通知的 Cloud Function 与 Blaze plan 使用有关。",
+    firebasePricingLink: "Firebase 价格",
+    budgetAlertsLink: "Google Cloud 预算提醒",
     appNameLabel: "应用名称",
     packageNameLabel: "Android package 名称",
     fixedAppInfoTitle: "分发 APK 的固定设置",

--- a/pc-bridge/setup-web/index.html
+++ b/pc-bridge/setup-web/index.html
@@ -69,6 +69,21 @@
 
       <section class="panel span-2">
         <div class="section-heading">
+          <h2 data-i18n="costNoticeTitle">Firebase cost notice</h2>
+          <p data-i18n="costNoticeSubtitle">This app uses your own Firebase/GCP project, so billing and budget alerts belong to that project.</p>
+        </div>
+        <div class="notice">
+          <p data-i18n="costNoticeBody">Firestore reads/writes, Cloud Functions invocations, Cloud Logging, and Functions-related Google Cloud services can create billable usage. FCM is listed by Firebase as a no-cost product, but the Cloud Function that sends completion notifications requires Blaze plan usage.</p>
+          <p>
+            <a href="https://firebase.google.com/pricing" target="_blank" rel="noreferrer" data-i18n="firebasePricingLink">Firebase pricing</a>
+            ·
+            <a href="https://docs.cloud.google.com/billing/docs/how-to/budgets" target="_blank" rel="noreferrer" data-i18n="budgetAlertsLink">Google Cloud budgets and alerts</a>
+          </p>
+        </div>
+      </section>
+
+      <section class="panel span-2">
+        <div class="section-heading">
           <h2 data-i18n="jsonRegistrationTitle">JSON Registration</h2>
           <p data-i18n="jsonRegistrationSubtitle">Use client config for the QR. Keep admin credentials on the PC side only.</p>
         </div>


### PR DESCRIPTION
## Summary
- READMEと利用者向けQuickstartへFirebase費用と予算アラートの注意点を追記
- Firestore/Functions/FCM/Logging/Functions周辺サービスの利用量目安を整理したFirebase費用ガイドを追加
- セットアップWeb UIに料金注意と公式料金/予算アラートリンクを追加

## Sources
- Firebase pricing: https://firebase.google.com/pricing
- Firebase pricing plans: https://firebase.google.com/docs/projects/billing/firebase-pricing-plans
- Google Cloud Budgets & alerts: https://docs.cloud.google.com/billing/docs/how-to/budgets

## Validation
- node --check setup-web/app.js
- npm.cmd run check
- npm.cmd test
- GET http://127.0.0.1:8789/

Closes #161