### PR TITLE
Release作業を自動化しRunbookを整備する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules/
 npm-debug.log*
 .env
 .env.*
+.local/
 pc-bridge/config.local.json
 pc-bridge/*.local.json
 pc-bridge/dist/

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ firebase deploy --only functions
 - [Cloud Functions手順](firebase/functions/README.md)
 - [Androidアプリ手順](app/README.md)
 - [配布準備](docs/distribution-prep.md)
+- [Release Runbook](docs/release-runbook.md)
 - [利用者向けクイックスタート](docs/user-quickstart.md)
 - [配布利用者向けトラブルシュート](docs/troubleshooting-distribution.md)
 

--- a/docs/release-apk.md
+++ b/docs/release-apk.md
@@ -1,5 +1,7 @@
 # release APK作成手順
 
+Release全体の自動化手順、PCブリッジzip、SHA256SUMS、Release note雛形、GitHub Release作成前チェックは [Release runbook](release-runbook.md) を参照する。
+
 この文書は、Codex Remote Androidを自分以外の利用者へ配布するためのAPK作成手順をまとめる。
 
 ## 方針

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,129 @@
+# Release runbook
+
+このRunbookはCodex Remote AndroidのRelease作業チェックリストである。署名鍵、`key.properties`、service account JSON、`config.local.json`、ログ、Firebase debug fileはローカル管理のままとし、GitHub Releaseへ添付しない。
+
+## 前提条件
+
+- `app/pubspec.yaml` がRelease対象の `versionName+versionCode` になっている。
+- `versionCode` が前回配布したAndroid buildより大きい。
+- `app/android/key.properties` がローカルに存在し、Release署名鍵を指している。
+- `app/android/app/google-services.json` がRelease対象Firebase projectのものになっている。
+- `pc-bridge/config.local.json` はローカル検証専用で、Git管理外のままになっている。
+- このPCからGitHub Releaseを作成する場合は `gh auth status` が成功する。
+
+## パッケージ前検証
+
+artifactを作成する前に主要チェックを実行する。
+
+```powershell
+Set-Location app
+flutter test
+flutter analyze
+
+Set-Location ..\pc-bridge
+npm.cmd run check
+npm.cmd test
+```
+
+## artifact作成
+
+repository rootからRelease helperを実行する。
+
+```powershell
+.\scripts\prepare-release.ps1 -PreviousVersionCode <previousVersionCode>
+```
+
+既存のAPKとPCブリッジzipを使ってdry runする場合:
+
+```powershell
+.\scripts\prepare-release.ps1 -SkipApkBuild -SkipPcBridgePackage
+```
+
+helperは次の処理を行う。
+
+- `app/pubspec.yaml` のversion解析。
+- 任意指定した前回 `versionCode` との比較。
+- skipしない場合のrelease APK build。
+- `apksigner verify --verbose`。
+- `aapt dump badging` によるpackage/version確認。
+- skipしない場合のPCブリッジzip作成。
+- PCブリッジzipにローカル専用ファイルや秘密情報らしいファイルが含まれていないことの検査。
+- `SHA256SUMS.txt` 生成。
+- Release note雛形生成。
+
+出力先:
+
+```text
+.local/release/<versionName>/
+```
+
+期待されるartifact:
+
+- `RemoteCodex-<versionName>.apk`
+- `codex-remote-pc-bridge-<versionName>.zip`
+- `SHA256SUMS.txt`
+- `release-notes-<versionName>.md`
+
+## E2E smoke
+
+実機へAPKをインストールした後、Release E2E smokeを実行する。
+
+```powershell
+.\scripts\run-android-e2e-smoke.ps1 `
+  -Install `
+  -ApkPath .\.local\release\<versionName>\RemoteCodex-<versionName>.apk `
+  -EvidencePath .\.local\release\<versionName>\e2e-smoke.json
+```
+
+続けて [Release E2E smoke runbook](release-e2e-smoke.md) に従い、次を記録する。
+
+- device modelとAndroid version
+- app `versionName/versionCode`
+- PC bridge heartbeatとhealth check response
+- session IDとcommand ID
+- completed command status
+- notification success count
+
+## GitHub Release前チェック
+
+GitHub Releaseを作成する前にartifact directoryを確認する。
+
+```powershell
+Get-ChildItem .\.local\release\<versionName>
+Get-Content .\.local\release\<versionName>\SHA256SUMS.txt
+```
+
+次はアップロードしない。
+
+- `key.properties`
+- `*.jks`, `*.keystore`, `*.p12`
+- `serviceAccount*.json`
+- `config.local.json`
+- `google-services.json`
+- `.env`
+- logsまたはFirebase debug logs
+- redactしていないdiagnostic output
+
+## GitHub Release作成
+
+生成されたRelease noteを本文のベースにし、E2E evidenceと既知の制限を追記する。
+
+```powershell
+gh release create v<versionName> `
+  .\.local\release\<versionName>\RemoteCodex-<versionName>.apk `
+  .\.local\release\<versionName>\codex-remote-pc-bridge-<versionName>.zip `
+  .\.local\release\<versionName>\SHA256SUMS.txt `
+  --title "Codex Remote Android <versionName>" `
+  --notes-file .\.local\release\<versionName>\release-notes-<versionName>.md
+```
+
+公開後に次を確認する。
+
+- GitHub Release pageを開ける。
+- artifact名がRelease noteと一致する。
+- SHA256値がローカルファイルと一致する。
+- ローカル専用設定や秘密情報がアップロードされていない。
+
+## 文書化
+
+Release完了後、`docs/releases/<versionName>.md` にRelease evidenceを追加する。生成したRelease noteの要約、検証コマンド、E2E smoke結果、artifact hash、既知の制限、GitHub Releaseへのリンクを含める。

--- a/docs/releases/1.0.2.md
+++ b/docs/releases/1.0.2.md
@@ -4,6 +4,8 @@ Date: 2026-04-27
 
 Target issue: #142
 
+次回以降のRelease作業は [Release runbook](../release-runbook.md) に従う。
+
 ## Release target
 
 | Item | Value |

--- a/scripts/prepare-release.ps1
+++ b/scripts/prepare-release.ps1
@@ -1,0 +1,214 @@
+param(
+  [string]$Version = "",
+  [string]$PreviousVersionCode = "",
+  [switch]$SkipApkBuild,
+  [switch]$SkipPcBridgePackage,
+  [switch]$NoClean
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$AppDir = Join-Path $RepoRoot "app"
+$BridgeDir = Join-Path $RepoRoot "pc-bridge"
+$PubspecPath = Join-Path $AppDir "pubspec.yaml"
+$ReleaseRoot = Join-Path $RepoRoot ".local\release"
+
+function Invoke-Checked {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments,
+    [string]$WorkingDirectory = $RepoRoot
+  )
+
+  Push-Location $WorkingDirectory
+  try {
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+      throw "$FilePath exited with code $LASTEXITCODE"
+    }
+  } finally {
+    Pop-Location
+  }
+}
+
+function Find-AndroidBuildTool {
+  param([string]$Name)
+
+  $sdkRoot = $env:ANDROID_HOME
+  if (-not $sdkRoot) {
+    $sdkRoot = Join-Path $env:LOCALAPPDATA "Android\Sdk"
+  }
+
+  $tool = Get-ChildItem (Join-Path $sdkRoot "build-tools") -Recurse -Filter $Name -ErrorAction SilentlyContinue |
+    Sort-Object FullName -Descending |
+    Select-Object -First 1 -ExpandProperty FullName
+  if (-not $tool) {
+    throw "Android build tool was not found: $Name"
+  }
+
+  return $tool
+}
+
+function Assert-NotSensitiveArtifact {
+  param([string]$Path)
+
+  $name = Split-Path -Leaf $Path
+  $blocked = @(
+    "config.local.json",
+    "key.properties",
+    "google-services.json",
+    "firebase-debug.log",
+    "serviceAccount",
+    ".env",
+    ".keystore",
+    ".jks"
+  )
+
+  foreach ($term in $blocked) {
+    if ($name -like "*$term*") {
+      throw "Refusing to include sensitive-looking artifact: $name"
+    }
+  }
+}
+
+$pubspec = Get-Content -LiteralPath $PubspecPath -Raw
+if ($pubspec -notmatch "(?m)^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)\s*$") {
+  throw "app/pubspec.yaml must contain version: <versionName>+<versionCode>"
+}
+
+$versionName = $Matches[1]
+$versionCode = [int]$Matches[2]
+if ($Version -and $Version -ne $versionName) {
+  throw "Requested version $Version does not match app/pubspec.yaml versionName $versionName"
+}
+if ($PreviousVersionCode) {
+  $previousCode = [int]$PreviousVersionCode
+  if ($versionCode -le $previousCode) {
+    throw "versionCode $versionCode must be greater than previous versionCode $previousCode"
+  }
+}
+
+$releaseDir = Join-Path $ReleaseRoot $versionName
+New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+
+if (-not $SkipApkBuild) {
+  if (-not (Test-Path (Join-Path $AppDir "android\key.properties"))) {
+    throw "Missing app/android/key.properties. Create it before release APK build."
+  }
+
+  if (-not $NoClean) {
+    Invoke-Checked -FilePath "flutter" -Arguments @("clean") -WorkingDirectory $AppDir
+  }
+  Invoke-Checked -FilePath "flutter" -Arguments @("pub", "get") -WorkingDirectory $AppDir
+  Invoke-Checked -FilePath "flutter" -Arguments @("build", "apk", "--release") -WorkingDirectory $AppDir
+}
+
+$apkPath = Join-Path $AppDir "build\app\outputs\flutter-apk\app-release.apk"
+if (-not (Test-Path -LiteralPath $apkPath)) {
+  throw "Release APK was not found: $apkPath"
+}
+
+$apksigner = Find-AndroidBuildTool "apksigner.bat"
+Invoke-Checked -FilePath $apksigner -Arguments @("verify", "--verbose", $apkPath)
+
+$aapt = Find-AndroidBuildTool "aapt.exe"
+$badging = & $aapt dump badging $apkPath
+if ($LASTEXITCODE -ne 0) {
+  throw "aapt dump badging failed."
+}
+if (($badging -join "`n") -notmatch "package: name='com\.sunmax\.remotecodex' versionCode='$versionCode' versionName='$versionName'") {
+  throw "APK metadata does not match app/pubspec.yaml version/package."
+}
+
+$apkOut = Join-Path $releaseDir "RemoteCodex-$versionName.apk"
+Copy-Item -LiteralPath $apkPath -Destination $apkOut -Force
+Assert-NotSensitiveArtifact $apkOut
+
+if (-not $SkipPcBridgePackage) {
+  Invoke-Checked -FilePath "npm.cmd" -Arguments @("run", "package:dist") -WorkingDirectory $BridgeDir
+}
+
+$bridgeZip = Join-Path $BridgeDir ".local\distribution\codex-remote-pc-bridge.zip"
+if (-not (Test-Path -LiteralPath $bridgeZip)) {
+  throw "PC bridge distribution zip was not found: $bridgeZip"
+}
+
+$bridgeOut = Join-Path $releaseDir "codex-remote-pc-bridge-$versionName.zip"
+Copy-Item -LiteralPath $bridgeZip -Destination $bridgeOut -Force
+Assert-NotSensitiveArtifact $bridgeOut
+
+$zipEntries = [System.IO.Compression.ZipFile]::OpenRead($bridgeOut)
+try {
+  foreach ($entry in $zipEntries.Entries) {
+    $entryName = $entry.FullName
+    foreach ($blocked in @("config.local.json", "node_modules/", "logs/", ".local/", "key.properties", ".env", ".jks", ".keystore", "serviceAccount")) {
+      if ($entryName -like "*$blocked*") {
+        throw "Sensitive or local-only file found in PC bridge zip: $entryName"
+      }
+    }
+  }
+} finally {
+  $zipEntries.Dispose()
+}
+
+$hashPath = Join-Path $releaseDir "SHA256SUMS.txt"
+$artifacts = @($apkOut, $bridgeOut)
+$hashLines = foreach ($artifact in $artifacts) {
+  $hash = Get-FileHash -Algorithm SHA256 -LiteralPath $artifact
+  "$($hash.Hash)  $(Split-Path -Leaf $artifact)"
+}
+Set-Content -LiteralPath $hashPath -Value $hashLines -Encoding ascii
+
+$releaseNotePath = Join-Path $releaseDir "release-notes-$versionName.md"
+$commit = (& git -C $RepoRoot rev-parse HEAD).Trim()
+$date = Get-Date -Format "yyyy-MM-dd"
+$releaseNote = @"
+# Codex Remote Android $versionName
+
+## Summary
+
+- Release date: $date
+- Commit: $commit
+- Android version: $versionName+$versionCode
+- Android package: com.sunmax.remotecodex
+
+## Artifacts
+
+- RemoteCodex-$versionName.apk
+- codex-remote-pc-bridge-$versionName.zip
+- SHA256SUMS.txt
+
+## Validation
+
+- [ ] flutter test
+- [ ] flutter analyze
+- [ ] npm.cmd test in pc-bridge
+- [ ] npm.cmd run check in pc-bridge
+- [ ] apksigner verify --verbose
+- [ ] aapt dump badging version/package check
+- [ ] PC bridge zip inspection excludes config.local.json, logs, node_modules, .local, key material, and service account JSON
+- [ ] Release E2E smoke evidence recorded
+
+## Notes
+
+- Do not upload key.properties, keystore/JKS files, service account JSON, config.local.json, logs, .env files, or google-services.json.
+- Existing debug-signed installs may need uninstall before installing this release APK.
+"@
+Set-Content -LiteralPath $releaseNotePath -Value $releaseNote -Encoding utf8
+
+$summary = [ordered]@{
+  versionName = $versionName
+  versionCode = $versionCode
+  releaseDir = $releaseDir
+  artifacts = @(
+    (Split-Path -Leaf $apkOut),
+    (Split-Path -Leaf $bridgeOut),
+    (Split-Path -Leaf $hashPath),
+    (Split-Path -Leaf $releaseNotePath)
+  )
+}
+
+$summary | ConvertTo-Json -Depth 4


### PR DESCRIPTION
## 概要
- Release artifact作成用の `scripts/prepare-release.ps1` を追加
- Release手順、artifact検査、GitHub Release前チェックを `docs/release-runbook.md` に整理
- README、release APK手順、1.0.2 evidenceからRunbookへリンク
- 生成物出力先の `.local/` をGit管理外に追加

## 検証
- `flutter test`（app）
- `flutter analyze`（app）
- `npm.cmd run check`（pc-bridge）
- `npm.cmd test`（pc-bridge）
- `npm.cmd run package:dist`（pc-bridge）
- `scripts/prepare-release.ps1` PowerShell parse
- `.\scripts\prepare-release.ps1 -SkipApkBuild -SkipPcBridgePackage -PreviousVersionCode 1`
- `git diff --check`

Closes #162