### PR TITLE
CIでbuild/test/audit/release前チェックを実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,158 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Optional release tag to validate, for example v1.0.2"
+        required: false
+        type: string
+      require_release_notes:
+        description: "Require docs/releases/<version>.md"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  flutter:
+    name: Flutter analyze/test
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        working-directory: app
+        run: flutter pub get
+
+      - name: Analyze Flutter app
+        working-directory: app
+        run: flutter analyze
+
+      - name: Run Flutter tests
+        working-directory: app
+        run: flutter test
+
+  pc-bridge:
+    name: PC bridge check/test/audit
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: pc-bridge/package-lock.json
+
+      - name: Install PC bridge dependencies
+        working-directory: pc-bridge
+        run: npm.cmd ci
+
+      - name: Typecheck PC bridge
+        working-directory: pc-bridge
+        run: npm.cmd run check
+
+      - name: Test PC bridge
+        working-directory: pc-bridge
+        run: npm.cmd test
+
+      - name: Audit PC bridge dependencies
+        working-directory: pc-bridge
+        run: npm.cmd audit --audit-level=high
+
+  firebase:
+    name: Firebase functions/rules check/test/audit
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: firebase/functions/package-lock.json
+
+      - name: Setup Java for Firestore Emulator
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Install Firebase Functions dependencies
+        working-directory: firebase/functions
+        run: npm.cmd ci
+
+      - name: Typecheck Firebase Functions
+        working-directory: firebase/functions
+        run: npm.cmd run check
+
+      - name: Build Firebase Functions
+        working-directory: firebase/functions
+        run: npm.cmd run build
+
+      - name: Test Firebase Functions
+        working-directory: firebase/functions
+        run: npm.cmd run test:functions
+
+      - name: Audit Firebase Functions dependencies
+        working-directory: firebase/functions
+        run: npm.cmd audit --audit-level=high
+
+      - name: Install Firebase CLI
+        run: npm.cmd install -g firebase-tools
+
+      - name: Test Firestore Rules
+        working-directory: firebase/functions
+        run: npm.cmd run test:rules
+
+  release-readiness:
+    name: Release readiness check
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check release metadata
+        shell: pwsh
+        env:
+          GITHUB_REF_TYPE_VALUE: ${{ github.ref_type }}
+          GITHUB_REF_NAME_VALUE: ${{ github.ref_name }}
+          RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag }}
+          REQUIRE_RELEASE_NOTES_INPUT: ${{ github.event.inputs.require_release_notes }}
+        run: |
+          $tag = $env:RELEASE_TAG_INPUT
+          if (-not $tag -and $env:GITHUB_REF_TYPE_VALUE -eq "tag") {
+            $tag = $env:GITHUB_REF_NAME_VALUE
+          }
+
+          $arguments = @()
+          if ($tag) {
+            $arguments += @("-Tag", $tag)
+          }
+          if ($env:REQUIRE_RELEASE_NOTES_INPUT -eq "true") {
+            $arguments += "-RequireReleaseNotes"
+          }
+
+          .\scripts\check-release-readiness.ps1 @arguments

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ firebase/firebase-debug.log
 firebase/.env
 firebase/functions/.env
 firebase/functions/lib/
+firebase/functions/firestore-debug.log
 
 # Node / bridge
 node_modules/

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ firebase deploy --only functions
 - [Androidアプリ手順](app/README.md)
 - [配布準備](docs/distribution-prep.md)
 - [Release Runbook](docs/release-runbook.md)
+- [CI](docs/ci.md)
 - [利用者向けクイックスタート](docs/user-quickstart.md)
 - [配布利用者向けトラブルシュート](docs/troubleshooting-distribution.md)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,48 @@
+# CI
+
+GitHub Actionsでは、秘密情報を必要としない範囲のPR/Release前チェックを自動実行する。
+
+## workflow
+
+`.github/workflows/ci.yml` は次の契機で実行する。
+
+- `main` 宛てのPull Request
+- `main` へのpush
+- `v*` tagへのpush
+- 手動実行
+
+## 実行内容
+
+- Flutter app
+  - `flutter pub get`
+  - `flutter analyze`
+  - `flutter test`
+- PC bridge
+  - `npm.cmd ci`
+  - `npm.cmd run check`
+  - `npm.cmd test`
+  - `npm.cmd audit --audit-level=high`
+- Firebase Functions / Firestore Rules
+  - `npm.cmd ci`
+  - `npm.cmd run check`
+  - `npm.cmd run build`
+  - `npm.cmd run test:functions`
+  - `npm.cmd audit --audit-level=high`
+  - `npm.cmd run test:rules`
+- Release readiness
+  - `app/pubspec.yaml` の `versionName+versionCode` を検査する。
+  - `docs/release-runbook.md` が存在することを検査する。
+  - `v*` tagまたは手動指定tagでは、tagが `v<versionName>` と一致することを検査する。
+  - tag検査時は `docs/releases/<versionName>.md` が存在し、versionName/versionCodeを含むことも検査する。
+
+## 秘密情報の扱い
+
+CIではRelease署名、実Firebase projectへのdeploy、実Firebase E2E、FCM実送信を行わない。次のファイルや値はGitHub Actionsへ渡さない。
+
+- `app/android/key.properties`
+- keystore / JKS / p12
+- Firebase service account JSON
+- `pc-bridge/config.local.json`
+- `.env`
+
+Release署名と実機E2Eは [Release runbook](release-runbook.md) と [Release E2E smoke runbook](release-e2e-smoke.md) に従ってローカルで実施する。

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -15,6 +15,8 @@
 
 artifactを作成する前に主要チェックを実行する。
 
+PRとRelease前の自動チェックは [CI](ci.md) に記録している。Release署名と実Firebase E2EはローカルRunbookの対象とし、CIには署名鍵やservice account JSONを渡さない。
+
 ```powershell
 Set-Location app
 flutter test

--- a/scripts/check-release-readiness.ps1
+++ b/scripts/check-release-readiness.ps1
@@ -1,0 +1,58 @@
+param(
+  [string]$Tag = "",
+  [switch]$RequireReleaseNotes
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$PubspecPath = Join-Path $RepoRoot "app\pubspec.yaml"
+$ReleaseRunbookPath = Join-Path $RepoRoot "docs\release-runbook.md"
+
+$pubspec = Get-Content -LiteralPath $PubspecPath -Raw
+if ($pubspec -notmatch "(?m)^version:\s*([0-9]+\.[0-9]+\.[0-9]+)\+([0-9]+)\s*$") {
+  throw "app/pubspec.yaml must contain version: <versionName>+<versionCode>"
+}
+
+$versionName = $Matches[1]
+$versionCode = [int]$Matches[2]
+if ($versionCode -lt 1) {
+  throw "versionCode must be greater than zero."
+}
+
+if (-not (Test-Path -LiteralPath $ReleaseRunbookPath)) {
+  throw "Release runbook was not found: docs/release-runbook.md"
+}
+
+if ($Tag) {
+  $expectedTag = "v$versionName"
+  if ($Tag -ne $expectedTag) {
+    throw "Release tag $Tag does not match app/pubspec.yaml versionName. Expected $expectedTag."
+  }
+  $RequireReleaseNotes = $true
+}
+
+if ($RequireReleaseNotes) {
+  $releaseDocPath = Join-Path $RepoRoot "docs\releases\$versionName.md"
+  if (-not (Test-Path -LiteralPath $releaseDocPath)) {
+    throw "Release evidence document was not found: docs/releases/$versionName.md"
+  }
+
+  $releaseDoc = Get-Content -LiteralPath $releaseDocPath -Raw
+  if ($releaseDoc -notmatch [regex]::Escape($versionName)) {
+    throw "Release evidence document does not mention versionName $versionName."
+  }
+  if ($releaseDoc -notmatch "(?m)(versionCode|build number).*$versionCode") {
+    throw "Release evidence document does not mention versionCode $versionCode."
+  }
+}
+
+$summary = [ordered]@{
+  versionName = $versionName
+  versionCode = $versionCode
+  expectedTag = "v$versionName"
+  releaseNotesRequired = [bool]$RequireReleaseNotes
+}
+
+$summary | ConvertTo-Json -Depth 3


### PR DESCRIPTION
## 概要
- GitHub Actions workflowを追加し、Flutter / PCブリッジ / Firebase Functions・RulesのチェックをPR・main pushで実行
- PCブリッジとFunctionsで `npm audit --audit-level=high` をCI化
- `scripts/check-release-readiness.ps1` を追加し、versionName/versionCode、Release runbook、tag `v<versionName>`、Release evidenceの整合を確認
- CI内容と秘密情報を扱わない範囲を `docs/ci.md` に記録し、README/Release Runbookからリンク

## 検証
- `flutter analyze`（app）
- `flutter test`（app）
- `npm.cmd run check`（pc-bridge）
- `npm.cmd test`（pc-bridge）
- `npm.cmd audit --audit-level=high`（pc-bridge。low/moderateのみで通過）
- `npm.cmd run check`（firebase/functions）
- `npm.cmd run build`（firebase/functions）
- `npm.cmd run test:functions`（firebase/functions）
- `npm.cmd audit --audit-level=high`（firebase/functions。low/moderateのみで通過）
- `npm.cmd run test:rules`（firebase/functions）
- `scripts/check-release-readiness.ps1` parse
- `.\scripts\check-release-readiness.ps1`
- `.\scripts\check-release-readiness.ps1 -Tag v1.0.2`
- `git diff --check`

補足: ローカル環境には実行可能な `actionlint` がなく、workflow構文はPR上のGitHub Actions実行で最終確認する。

Closes #163